### PR TITLE
fix: 修正 LXGW WenKai 字体包名(404 → 200)

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -17,7 +17,7 @@ const base = import.meta.env.BASE_URL;
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+SC:wght@400;500;700;900&family=Noto+Serif+SC:wght@400;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
-    <link href="https://cdn.jsdelivr.net/npm/lxgw-wenkai-web-font@1.7.0/style.css" rel="stylesheet" />
+    <link href="https://cdn.jsdelivr.net/npm/lxgw-wenkai-webfont@1.7.0/style.css" rel="stylesheet" />
     <title>{title}</title>
     <meta name="description" content={description} />
   </head>


### PR DESCRIPTION
## 问题
`BaseLayout.astro` 引用的字体包名有误:

- ❌ `lxgw-wenkai-web-font`(多了连字符)→ jsdelivr **404**
- ✅ `lxgw-wenkai-webfont`(正确包名)→ **200**

该链接自添加起就一直 404(与本次仓库迁移无关),导致中文衬线字体回退到 `Noto Serif SC`。

## 修改
- 修正 `src/layouts/BaseLayout.astro` 中的 CDN 包名为 `lxgw-wenkai-webfont@1.7.0`
- 已确认该包声明的 `font-family: 'LXGW WenKai'` 与 `global.css` 的 `--font-serif` 变量一致

## 验证
- ✅ `npm run build` 通过
- ✅ 正确包 URL 返回 200,提供 `LXGW WenKai` 字族