### PR TITLE
chore: 添加 Issue 表单 + 引导问题讨论到 Discussions

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-content-correction.yml
+++ b/.github/ISSUE_TEMPLATE/01-content-correction.yml
@@ -1,0 +1,59 @@
+name: 📝 内容勘误
+description: 课程正文有错别字、表述不清，或技术描述有误
+title: "[勘误] "
+labels: ["勘误"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        感谢你帮我们打磨课程内容！🙏
+        小到一个错别字，大到一处技术错误，每一份反馈都很有价值。
+        > 只是想提问或讨论某个知识点？请移步 [Discussions](https://github.com/datawhalechina/deepagents-in-action/discussions)。
+  - type: dropdown
+    id: chapter
+    attributes:
+      label: 所在章节
+      description: 选择问题所在的章节
+      options:
+        - 准备篇（上）— AgentSeek CLI create
+        - 准备篇（下）— AgentSeek CLI skills
+        - 第 1 章 — 从 Agent Framework 到 Agent Harness
+        - 第 2 章 — 快速上手
+        - 第 3 章 — 虚拟文件系统
+        - 第 4 章 — 任务规划与分解
+        - 第 5 章 — 子 Agent 与上下文隔离
+        - 第 6 章 — 异步子 Agent
+        - 第 7 章 — Skills
+        - 第 8 章 — 长期记忆
+        - 课程网站（非章节正文）
+        - 其他 / 不确定
+    validations:
+      required: true
+  - type: input
+    id: location
+    attributes:
+      label: 具体位置
+      description: 小节标题、段落开头几个字，或截图链接，方便我们快速定位
+      placeholder: 例如：「3.2 六大工具」一节第二段
+  - type: textarea
+    id: problem
+    attributes:
+      label: 问题描述
+      description: 哪里有问题？错别字 / 表述不清 / 技术描述有误？
+      placeholder: 原文写的是……，这里应该是……
+    validations:
+      required: true
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: 建议修改（选填）
+      description: 如果涉及技术性勘误，欢迎附上参考链接或官方文档出处
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: 确认
+      options:
+        - label: 我已搜索过现有 Issue，确认这不是重复反馈
+          required: true
+        - label: （选填）我愿意提 PR 协助修正
+          required: false

--- a/.github/ISSUE_TEMPLATE/02-code-issue.yml
+++ b/.github/ISSUE_TEMPLATE/02-code-issue.yml
@@ -1,0 +1,67 @@
+name: 🐛 代码 / 环境问题
+description: 示例代码报错、环境装不上、本地跑不起来
+title: "[代码] "
+labels: ["代码问题"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        遇到代码或环境问题别着急,按下面填清楚,我们和其他同学都能更快帮到你。💪
+        > 如果只是「不确定该怎么用」这类开放性问题,建议先去 [Discussions Q&A](https://github.com/datawhalechina/deepagents-in-action/discussions/categories/q-a) 提问。
+  - type: dropdown
+    id: chapter
+    attributes:
+      label: 所在章节
+      description: 哪一章的代码 / 示例?
+      options:
+        - 准备篇（上）— AgentSeek CLI create
+        - 准备篇（下）— AgentSeek CLI skills
+        - 第 1 章 — 从 Agent Framework 到 Agent Harness
+        - 第 2 章 — 快速上手
+        - 第 3 章 — 虚拟文件系统
+        - 第 4 章 — 任务规划与分解
+        - 第 5 章 — 子 Agent 与上下文隔离
+        - 第 6 章 — 异步子 Agent
+        - 第 7 章 — Skills
+        - 第 8 章 — 长期记忆
+        - 其他 / 不确定
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: 问题描述 / 复现步骤
+      description: 你做了什么、期望发生什么、实际发生了什么?最好能让我们照着复现
+      placeholder: |
+        1. 运行 xxx
+        2. 期望：……
+        3. 实际：……
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: 报错信息 / 日志
+      description: 把完整的报错堆栈贴进来(会自动按代码块渲染,无需手动加反引号)
+      render: shell
+  - type: textarea
+    id: env
+    attributes:
+      label: 运行环境
+      description: 帮助我们排查环境相关问题
+      value: |
+        - 操作系统：（如 macOS 14 / Windows 11 / Ubuntu 22.04）
+        - Python 版本：（python --version）
+        - deepagents / langchain 版本：（pip show deepagents langchain）
+        - 模型供应商：（如 OpenAI / DeepSeek / Qwen / GLM）
+    validations:
+      required: true
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: 确认
+      options:
+        - label: 我已搜索过现有 Issue，确认这不是重复问题
+          required: true
+        - label: 我使用的是课程要求的依赖版本（Deep Agents ≥ 0.5）
+          required: false

--- a/.github/ISSUE_TEMPLATE/03-content-suggestion.yml
+++ b/.github/ISSUE_TEMPLATE/03-content-suggestion.yml
@@ -1,0 +1,30 @@
+name: 💡 内容 / 改进建议
+description: 希望补充某个主题、调整章节顺序，或对讲法提出改进
+title: "[建议] "
+labels: ["建议"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        欢迎你为课程出谋划策!✨
+        > 涉及较大结构调整(如重写整章、新增篇章)的想法,建议先在 [Discussions Ideas](https://github.com/datawhalechina/deepagents-in-action/discussions/categories/ideas) 发起讨论,聊成熟了再开 Issue。
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: 建议内容
+      description: 你希望补充什么主题、怎么调整,或哪里可以讲得更好?
+      placeholder: 例如：希望在第 5 章补充一个多子 Agent 协作的完整示例……
+    validations:
+      required: true
+  - type: textarea
+    id: rationale
+    attributes:
+      label: 理由 / 场景（选填）
+      description: 为什么需要这个改进?你在什么场景下遇到了困惑?
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: 确认
+      options:
+        - label: 我已搜索过现有 Issue 和 Discussions，确认这不是重复建议
+          required: true

--- a/.github/ISSUE_TEMPLATE/04-site-bug.yml
+++ b/.github/ISSUE_TEMPLATE/04-site-bug.yml
@@ -1,0 +1,51 @@
+name: 🌐 网站问题
+description: 课程网站排版错乱、链接失效、图片加载不出来等
+title: "[网站] "
+labels: ["网站"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        感谢反馈网站问题!🛠️
+        > 💡 如果页面样式看起来错乱,**很可能是浏览器缓存**。请先按 `Cmd/Ctrl + Shift + R` 强制刷新,或用无痕窗口打开试试。仍有问题再提交。
+  - type: input
+    id: url
+    attributes:
+      label: 页面 URL
+      description: 出问题的页面链接
+      placeholder: https://datawhalechina.github.io/deepagents-in-action/chapters/...
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: 问题描述
+      description: 排版错乱 / 链接点不开 / 图片加载不出 / 其他?
+    validations:
+      required: true
+  - type: dropdown
+    id: device
+    attributes:
+      label: 设备 / 浏览器
+      options:
+        - 桌面端 — Chrome
+        - 桌面端 — Safari
+        - 桌面端 — Firefox
+        - 桌面端 — Edge
+        - 移动端 — iOS
+        - 移动端 — Android
+        - 其他 / 不确定
+    validations:
+      required: true
+  - type: textarea
+    id: screenshot
+    attributes:
+      label: 截图（选填）
+      description: 直接把截图拖进来即可,一图胜千言
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: 确认
+      options:
+        - label: 我已尝试强制刷新（Cmd/Ctrl + Shift + R）或无痕窗口，问题依然存在
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 💬 我有疑问 / 想提问（Q&A）
+    url: https://github.com/datawhalechina/deepagents-in-action/discussions/categories/q-a
+    about: 学习中卡住了、概念没搞懂？来 Q&A 提问，作者和同学都会帮你解答。
+  - name: 🗣️ 自由讨论 / 想法交流（General）
+    url: https://github.com/datawhalechina/deepagents-in-action/discussions/categories/general
+    about: 想聊聊 Agent 开发、分享思路或随便聊聊？来 General 板块。
+  - name: 🙌 展示你的作品（Show and tell）
+    url: https://github.com/datawhalechina/deepagents-in-action/discussions/categories/show-and-tell
+    about: 用 Deep Agents 做了好玩的东西？来这里晒一晒，互相启发。
+  - name: 📺 B 站视频合集
+    url: https://space.bilibili.com/28357052/lists/7757577?type=season
+    about: 配套视频讲解，边看边学。


### PR DESCRIPTION
为内测开放搭建结构化反馈入口。

## 改动
新增 `.github/ISSUE_TEMPLATE/` 下 5 个文件:

**4 个 Issue 表单(YAML Forms,中文)**
- 📝 `01-content-correction.yml` — 内容勘误(章节下拉 + 位置 + 问题描述 + 建议修改)
- 🐛 `02-code-issue.yml` — 代码/环境问题(复现步骤 + 报错日志 + 运行环境)
- 💡 `03-content-suggestion.yml` — 内容/改进建议
- 🌐 `04-site-bug.yml` — 网站问题(含「先强刷再提交」提示,呼应缓存坑)

**1 个配置**
- `config.yml` — 关闭空白 Issue,把「提问 / 讨论 / 晒作品」引导到 Discussions 的 Q&A / General / Show and tell,并附 B 站视频合集链接

## 说明
- 仅影响 GitHub Issue 创建页,与 Astro / Pages 构建无关
- 各表单含「已搜索过现有 Issue」必填确认项,降低重复
- 标签(勘误/代码问题/建议/网站)在首次使用时由 GitHub 自动创建