### PR TITLE
fix: 修正 CONTRIBUTING.md 和 README 中的仓库名称及图片路径说明

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,8 +24,8 @@
 ### 1. Fork 并克隆仓库
 
 ```bash
-git clone https://github.com/<your-username>/deepagents-site.git
-cd deepagents-site
+git clone https://github.com/<your-username>/deepagents-in-action.git
+cd deepagents-in-action
 ```
 
 ### 2. 安装依赖并启动开发服务器
@@ -81,7 +81,7 @@ docs: 改善第 X 章 <简要说明>
 - 中文与英文、数字之间加空格：`LangChain 是一个框架` ✓，`LangChain是一个框架` ✗
 - 代码、命令、变量名使用反引号包裹：`` `create_deep_agent()` ``
 - 专有名词保持原文大小写：`LangGraph`、`LangSmith`、`GitHub`
-- 图片路径使用相对路径：`![说明](imgs/xx.png)`（脚本会自动处理 base path）
+- 图片路径使用相对路径：`![说明](../public/imgs/xx.png)`（构建脚本会自动转换为正确的站点路径）
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ npm run preview
 ### 项目结构
 
 ```
-deepagents-site/
+deepagents-in-action/
 ├── content/          # 章节正文（Markdown，每章一个文件）
 │   ├── ch01-agent-harness.md
 │   ├── ch02-quickstart.md


### PR DESCRIPTION
## 问题描述

CONTRIBUTING.md 和 README.md 中存在两处事实性错误，会直接影响新贡献者的体验：

1. **仓库名称错误**：文档中写的是旧名 `deepagents-site`，实际仓库名为 `deepagents-in-action`。新贡献者照着文档 clone 会找不到仓库。
2. **图片路径规范与 CI 规则矛盾**：`CONTRIBUTING.md` 中写的图片路径格式是 `![说明](imgs/xx.png)`，但 `check-image-paths.yml` CI 检查明确要求使用 `../public/imgs/xx.png`。贡献者按文档操作，提交的 PR 会被 CI 拒绝。

## 修改内容

- `CONTRIBUTING.md`：将 `deepagents-site` 修正为 `deepagents-in-action`（第 27-28 行）
- `CONTRIBUTING.md`：将图片路径说明从 `imgs/xx.png` 修正为 `../public/imgs/xx.png`，与 CI 规则保持一致（第 84 行）
- `README.md`：将项目结构标题 `deepagents-site/` 修正为 `deepagents-in-action/`（第 114 行）