### PR TITLE
fix: 修复章节导航中准备篇显示为第 0 章的问题

### DIFF
--- a/src/components/ChapterNav.astro
+++ b/src/components/ChapterNav.astro
@@ -14,7 +14,7 @@ const base = import.meta.env.BASE_URL;
       <a href={`${base}/chapters/${prev.id}/`} class="flex-1 group py-3 px-4 -mx-4 rounded-lg hover:bg-paper-warm transition-colors">
         <span class="text-[11px] font-mono tracking-wider text-ink-muted/40 group-hover:text-gold transition-colors">上一章</span>
         <p class="text-sm font-medium font-sans mt-1 text-ink-muted group-hover:text-ink transition-colors leading-snug">
-          第 {prev.chapter} 章：{prev.title}
+          {prev.chapter === 0 ? prev.title : `第 ${prev.chapter} 章：${prev.title}`}
         </p>
       </a>
     ) : <div />}
@@ -22,7 +22,7 @@ const base = import.meta.env.BASE_URL;
       <a href={`${base}/chapters/${next.id}/`} class="flex-1 text-right group py-3 px-4 -mx-4 rounded-lg hover:bg-paper-warm transition-colors">
         <span class="text-[11px] font-mono tracking-wider text-ink-muted/40 group-hover:text-gold transition-colors">下一章</span>
         <p class="text-sm font-medium font-sans mt-1 text-ink-muted group-hover:text-ink transition-colors leading-snug">
-          第 {next.chapter} 章：{next.title}
+          {next.chapter === 0 ? next.title : `第 ${next.chapter} 章：${next.title}`}
         </p>
       </a>
     ) : <div />}


### PR DESCRIPTION
## 问题描述

`chapters.json` 中准备篇（`pre01-agentseek-create`、`pre02-agentseek-skills`）的 `chapter` 字段为 `0`。`ChapterNav.astro` 组件中硬编码了「第 X 章：」前缀，导致用户从第 1 章向前导航或在准备篇之间导航时，显示为**「第 0 章：AgentSeek CLI（上）…」**，不符合预期。

`ChapterLayout.astro` 已通过 `isExtra`（`section === '准备篇'`）判断避免了此问题，但 `ChapterNav` 缺少同等处理。

## 修改内容

- `src/components/ChapterNav.astro`：当 `chapter === 0` 时直接显示标题，不加「第 X 章：」前缀

## 影响范围

仅影响章节底部的上一章/下一章导航组件，涉及准备篇相邻章节的导航显示。
