### PR TITLE
fix: 统一 Footer 官方文档链接并移除 .gitignore 重复条目

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,3 @@ node_modules/
 
 # astro
 .astro/
-node_modules/

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -32,7 +32,7 @@
         <a href="https://space.bilibili.com/28357052/lists/7757577?type=season" target="_blank" rel="noopener"
           class="hover:text-ink-muted transition-colors">B站</a>
         <span class="text-gold/20">|</span>
-        <a href="https://docs.langchain.com/docs/deepagents/" target="_blank" rel="noopener"
+        <a href="https://docs.langchain.com/oss/python/deepagents/overview" target="_blank" rel="noopener"
           class="hover:text-ink-muted transition-colors">官方文档</a>
         <span class="text-gold/20">|</span>
         <a href="https://github.com/langchain-ai/deepagents" target="_blank" rel="noopener"


### PR DESCRIPTION
## 问题描述

1. **Footer 官方文档链接过时**：`Footer.astro` 中的官方文档链接为 `https://docs.langchain.com/docs/deepagents/`，而 `README.md` 中使用的是 `https://docs.langchain.com/oss/python/deepagents/overview`，两者不一致，Footer 中的链接可能已失效。
2. **`.gitignore` 重复条目**：`node_modules/` 在文件中出现了两次（第 8 行和第 12 行），第二次为冗余。

## 修改内容

- `src/components/Footer.astro`：将官方文档链接统一为 `https://docs.langchain.com/oss/python/deepagents/overview`，与 README 保持一致
- `.gitignore`：移除重复的 `node_modules/` 条目
