### PR TITLE
fix: 替换已下线模型 + 补充 ch02 依赖安装 (#24, #25)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@
 > 部分进阶功能有更高最低版本要求，章节正文会单独标注；例如 `FilesystemPermission` 基础权限需要 `deepagents>=0.5.2`，`interrupt` 权限模式需要 `deepagents>=0.6.8`。
 > 官方文档：[Deep Agents Overview](https://docs.langchain.com/oss/python/deepagents/overview)
 
+> [!NOTE]
+> **模型选择**：示例默认通过 [硅基流动](https://cloud.siliconflow.cn/) 接入模型。入门与简单任务使用免费的 `Qwen/Qwen2.5-7B-Instruct` 即可；但任务规划、上下文总结、多子 Agent 编排等复杂场景，小模型往往**无法稳定跑通**，请改用 SOTA 模型 `Pro/zai-org/GLM-5.1`。建议用 `MODEL_NAME` 环境变量管理模型名，而非写死在代码里。平台模型会不定期上下线，最新可用模型见 [模型广场](https://cloud.siliconflow.cn/models)。
+
 ---
 
 ## 课程大纲

--- a/content/ch02-quickstart.md
+++ b/content/ch02-quickstart.md
@@ -42,7 +42,7 @@ export MODEL_NAME="Qwen/Qwen2.5-7B-Instruct"   # 免费、支持 Tools，适合�
 
 > 当然，你也可以使用其他提供商（Anthropic、OpenAI、Google 等），只需配置对应的 API Key 即可。本系列的所有示例代码都以硅基流动为默认配置，但原理完全相同。
 
-> **模型版本维护说明**：本系列示例默认使用免费的 `Qwen/Qwen2.5-7B-Instruct`（轻量、支持工具调用，适合学习）；需要更强效果时推荐付费的 `Pro/zai-org/GLM-5.1`。平台模型会不定期上下线，**建议用上面的 `MODEL_NAME` 环境变量管理模型名，而非写死在代码里**——这样模型变更时只需改一处环境变量。最新可用模型见 [模型广场](https://cloud.siliconflow.cn/models)。
+> **模型版本维护说明**：本系列示例默认使用免费的 `Qwen/Qwen2.5-7B-Instruct`（轻量、支持工具调用，适合入门学习与简单任务）。**注意：任务规划、上下文总结、多子 Agent 编排等复杂场景，以及叠加了中间件的进阶示例，小模型（如 7B）往往无法稳定跑通完整流程，请使用 SOTA 模型 `Pro/zai-org/GLM-5.1`**——后续 ch04 / ch05 等章节会按场景标注推荐模型。平台模型会不定期上下线，**建议用上面的 `MODEL_NAME` 环境变量管理模型名，而非写死在代码里**——这样模型变更时只需改一处环境变量。最新可用模型见 [模型广场](https://cloud.siliconflow.cn/models)。
 
 ## Hello World：最简单的 Deep Agent
 
@@ -328,12 +328,12 @@ agent = create_deep_agent(model="openai:gpt-4.1")
 | 模型 | 参数量 | 特点 |
 |---|---|---|
 | `Pro/zai-org/GLM-5.1` | 744B (MoE, 40B 激活) | 智谱最新旗舰，Agent 任务同类最佳，支持推理模式 |
-| `Pro/moonshotai/Kimi-K2.5` | 1T (MoE, 32B 激活) | Kimi 最新旗舰，原生多模态智能体模型，256K 上下文 |
-| `Qwen/Qwen3.5-27B` | 27B | Qwen 最新系列，支持思考模式和视觉理解 |
+| `Pro/moonshotai/Kimi-K2.6` | 1T (MoE, 32B 激活) | Kimi 最新旗舰，原生多模态智能体模型，256K 上下文 |
+| `Pro/deepseek-ai/DeepSeek-V4-Pro` | 671B (MoE) | 推理和 Agent 能力顶级 |
+| `Qwen/Qwen3.6-27B` | 27B | Qwen 最新系列，支持思考模式和视觉理解 |
 | `Qwen/Qwen3.5-122B-A10B` | 122B (MoE, 10B 激活) | 旗舰级 MoE，仅 10B 激活参数，性价比极高 |
-| `deepseek-ai/DeepSeek-V3.2` | 671B (MoE) | 推理和 Agent 能力顶级 |
 
-> 本系列示例代码默认使用免费的 `Qwen/Qwen2.5-7B-Instruct` 以降低学习门槛。实际项目中推荐使用 GLM-5.1、Kimi-K2.5 或 Qwen3.5 系列的更大尺寸模型，效果更佳。建议用 `MODEL_NAME` 环境变量管理模型名，避免写死在代码中；完整模型列表见 [模型广场](https://cloud.siliconflow.cn/models)。
+> 本系列示例代码默认使用免费的 `Qwen/Qwen2.5-7B-Instruct` 以降低入门门槛，它足以跑通本章的简单示例。但任务规划、多 Agent 编排等复杂场景小模型往往无法稳定完成，需改用 GLM-5.1、Kimi-K2.6 或 Qwen3.6 系列等更大尺寸模型。建议用 `MODEL_NAME` 环境变量管理模型名，避免写死在代码中；完整模型列表见 [模型广场](https://cloud.siliconflow.cn/models)。
 
 ## 调试与追踪：LangSmith
 

--- a/content/ch02-quickstart.md
+++ b/content/ch02-quickstart.md
@@ -36,9 +36,13 @@ Deep Agents 支持多种模型提供商。你需要至少配置一个模型的 A
 
 ```bash
 export SILICONFLOW_API_KEY="your-siliconflow-key"
+# 可选：通过环境变量指定模型，方便整体切换，不必逐处修改代码
+export MODEL_NAME="Qwen/Qwen2.5-7B-Instruct"   # 免费、支持 Tools，适合学习
 ```
 
 > 当然，你也可以使用其他提供商（Anthropic、OpenAI、Google 等），只需配置对应的 API Key 即可。本系列的所有示例代码都以硅基流动为默认配置，但原理完全相同。
+
+> **模型版本维护说明**：本系列示例默认使用免费的 `Qwen/Qwen2.5-7B-Instruct`（轻量、支持工具调用，适合学习）；需要更强效果时推荐付费的 `Pro/zai-org/GLM-5.1`。平台模型会不定期上下线，**建议用上面的 `MODEL_NAME` 环境变量管理模型名，而非写死在代码里**——这样模型变更时只需改一处环境变量。最新可用模型见 [模型广场](https://cloud.siliconflow.cn/models)。
 
 ## Hello World：最简单的 Deep Agent
 
@@ -51,7 +55,8 @@ from deepagents import create_deep_agent
 
 # 通过硅基流动接入模型（兼容 OpenAI 接口）
 model = ChatOpenAI(
-    model="THUDM/glm-4-9b-chat",  # 硅基流动上免费且支持 Tools 的模型
+    # 默认免费模型，可用 MODEL_NAME 环境变量覆盖（如付费的 Pro/zai-org/GLM-5.1）
+    model=os.environ.get("MODEL_NAME", "Qwen/Qwen2.5-7B-Instruct"),
     api_key=os.environ["SILICONFLOW_API_KEY"],
     base_url="https://api.siliconflow.cn/v1",
 )
@@ -192,9 +197,9 @@ def internet_search(
 from langchain_openai import ChatOpenAI
 from deepagents import create_deep_agent
 
-# 使用硅基流动接入模型（免费的 GLM-4-9B 即可跑通，实际项目推荐 GLM-5）
+# 使用硅基流动接入模型（默认免费的 Qwen2.5-7B 即可跑通，实际项目推荐 GLM-5.1）
 model = ChatOpenAI(
-    model="THUDM/glm-4-9b-chat",  # 免费模型，可替换为 "Pro/zai-org/GLM-5"
+    model=os.environ.get("MODEL_NAME", "Qwen/Qwen2.5-7B-Instruct"),  # 可用 MODEL_NAME 覆盖
     api_key=os.environ["SILICONFLOW_API_KEY"],
     base_url="https://api.siliconflow.cn/v1",
 )
@@ -262,7 +267,7 @@ from langchain_openai import ChatOpenAI
 
 # 硅基流动（免费模型，适合学习）
 model = ChatOpenAI(
-    model="THUDM/glm-4-9b-chat",
+    model="Qwen/Qwen2.5-7B-Instruct",
     api_key=os.environ["SILICONFLOW_API_KEY"],
     base_url="https://api.siliconflow.cn/v1",
 )
@@ -270,7 +275,7 @@ agent = create_deep_agent(model=model)
 
 # 硅基流动（推荐模型，效果更好）
 model = ChatOpenAI(
-    model="Pro/zai-org/GLM-5",
+    model="Pro/zai-org/GLM-5.1",
     api_key=os.environ["SILICONFLOW_API_KEY"],
     base_url="https://api.siliconflow.cn/v1",
 )
@@ -287,7 +292,7 @@ agent = create_deep_agent(model=model)
 from langchain_anthropic import ChatAnthropic
 
 model = ChatAnthropic(
-    model="Pro/zai-org/GLM-5",
+    model="Pro/zai-org/GLM-5.1",
     api_key=os.environ["SILICONFLOW_API_KEY"],
     base_url="https://api.siliconflow.cn",
 )
@@ -316,19 +321,19 @@ agent = create_deep_agent(model="openai:gpt-4.1")
 
 | 模型 | 参数量 | 特点 |
 |---|---|---|
-| `THUDM/glm-4-9b-chat` | 9B | 中文理解优秀，128K 上下文，支持 Tools，**永久免费** |
+| `Qwen/Qwen2.5-7B-Instruct` | 7B | 中文理解优秀，支持 Tools，轻量快速，**免费** |
 
 **推荐模型（适合实际使用）：**
 
 | 模型 | 参数量 | 特点 |
 |---|---|---|
-| `Pro/zai-org/GLM-5` | 744B (MoE, 40B 激活) | 智谱最新旗舰，Agent 任务同类最佳，支持推理模式 |
+| `Pro/zai-org/GLM-5.1` | 744B (MoE, 40B 激活) | 智谱最新旗舰，Agent 任务同类最佳，支持推理模式 |
 | `Pro/moonshotai/Kimi-K2.5` | 1T (MoE, 32B 激活) | Kimi 最新旗舰，原生多模态智能体模型，256K 上下文 |
 | `Qwen/Qwen3.5-27B` | 27B | Qwen 最新系列，支持思考模式和视觉理解 |
 | `Qwen/Qwen3.5-122B-A10B` | 122B (MoE, 10B 激活) | 旗舰级 MoE，仅 10B 激活参数，性价比极高 |
 | `deepseek-ai/DeepSeek-V3.2` | 671B (MoE) | 推理和 Agent 能力顶级 |
 
-> 本系列示例代码默认使用免费的 `glm-4-9b-chat` 以降低学习门槛。实际项目中推荐使用 GLM-5、Kimi-K2.5 或 Qwen3.5 系列的更大尺寸模型，效果更佳。完整模型列表见 [模型广场](https://cloud.siliconflow.cn/models)。
+> 本系列示例代码默认使用免费的 `Qwen/Qwen2.5-7B-Instruct` 以降低学习门槛。实际项目中推荐使用 GLM-5.1、Kimi-K2.5 或 Qwen3.5 系列的更大尺寸模型，效果更佳。建议用 `MODEL_NAME` 环境变量管理模型名，避免写死在代码中；完整模型列表见 [模型广场](https://cloud.siliconflow.cn/models)。
 
 ## 调试与追踪：LangSmith
 
@@ -366,9 +371,9 @@ from langchain_openai import ChatOpenAI
 from tavily import TavilyClient
 from deepagents import create_deep_agent
 
-# 1. 配置模型（通过硅基流动接入，免费模型即可跑通）
+# 1. 配置模型（通过硅基流动接入，默认免费模型即可跑通）
 model = ChatOpenAI(
-    model="THUDM/glm-4-9b-chat",  # 免费模型，实际项目推荐 "Pro/zai-org/GLM-5"
+    model=os.environ.get("MODEL_NAME", "Qwen/Qwen2.5-7B-Instruct"),  # 实际项目推荐 "Pro/zai-org/GLM-5.1"
     api_key=os.environ["SILICONFLOW_API_KEY"],
     base_url="https://api.siliconflow.cn/v1",
 )

--- a/content/ch04-task-planning.md
+++ b/content/ch04-task-planning.md
@@ -153,7 +153,7 @@ from langchain.agents import create_agent
 from langchain.agents.middleware import TodoListMiddleware, FilesystemMiddleware
 
 model = ChatOpenAI(
-    model="THUDM/glm-4-9b-chat",
+    model="Qwen/Qwen2.5-7B-Instruct",
     api_key=os.environ["SILICONFLOW_API_KEY"],
     base_url="https://api.siliconflow.cn/v1",
 )
@@ -232,7 +232,7 @@ agent = create_agent(
         TodoListMiddleware(),
         FilesystemMiddleware(),   # read_file / write_file 通过中间件注入
         SummarizationMiddleware(
-            model="THUDM/glm-4-9b-chat",
+            model="Qwen/Qwen2.5-7B-Instruct",
             trigger=("tokens", 4000),  # 可自定义：("ratio", 0.85) 或 ("tokens", N)
             keep=("messages", 20),
         ),
@@ -255,7 +255,7 @@ from deepagents import create_deep_agent
 
 # 配置模型
 model = ChatOpenAI(
-    model="THUDM/glm-4-9b-chat",  # 免费模型，可替换为 "Pro/zai-org/GLM-5"
+    model="Qwen/Qwen2.5-7B-Instruct",  # 免费模型，可替换为 "Pro/zai-org/GLM-5.1"
     api_key=os.environ["SILICONFLOW_API_KEY"],
     base_url="https://api.siliconflow.cn/v1",
 )

--- a/content/ch04-task-planning.md
+++ b/content/ch04-task-planning.md
@@ -153,7 +153,8 @@ from langchain.agents import create_agent
 from langchain.agents.middleware import TodoListMiddleware, FilesystemMiddleware
 
 model = ChatOpenAI(
-    model="Qwen/Qwen2.5-7B-Instruct",
+    # 任务规划属于复杂推理场景，需要 SOTA 模型；小模型（如 7B）往往无法稳定完成多步骤规划任务
+    model="Pro/zai-org/GLM-5.1",
     api_key=os.environ["SILICONFLOW_API_KEY"],
     base_url="https://api.siliconflow.cn/v1",
 )
@@ -232,7 +233,7 @@ agent = create_agent(
         TodoListMiddleware(),
         FilesystemMiddleware(),   # read_file / write_file 通过中间件注入
         SummarizationMiddleware(
-            model="Qwen/Qwen2.5-7B-Instruct",
+            model="Pro/zai-org/GLM-5.1",  # 总结压缩影响后续推理质量，建议用 SOTA 模型
             trigger=("tokens", 4000),  # 可自定义：("ratio", 0.85) 或 ("tokens", N)
             keep=("messages", 20),
         ),
@@ -255,7 +256,8 @@ from deepagents import create_deep_agent
 
 # 配置模型
 model = ChatOpenAI(
-    model="Qwen/Qwen2.5-7B-Instruct",  # 免费模型，可替换为 "Pro/zai-org/GLM-5.1"
+    # 多步骤规划任务需要 SOTA 模型才能稳定完成；小模型可能无法跑通完整流程
+    model="Pro/zai-org/GLM-5.1",
     api_key=os.environ["SILICONFLOW_API_KEY"],
     base_url="https://api.siliconflow.cn/v1",
 )

--- a/content/ch05-subagents.md
+++ b/content/ch05-subagents.md
@@ -197,7 +197,8 @@ from langchain_openai import ChatOpenAI
 from deepagents import create_deep_agent
 
 model = ChatOpenAI(
-    model="Qwen/Qwen2.5-7B-Instruct",  # 免费模型，可替换为 "Pro/zai-org/GLM-5.1"
+    # 主 Agent 负责协调多个子 Agent，属于复杂编排场景，需要 SOTA 模型才能稳定完成
+    model="Pro/zai-org/GLM-5.1",
     api_key=os.environ["SILICONFLOW_API_KEY"],
     base_url="https://api.siliconflow.cn/v1",
 )

--- a/content/ch05-subagents.md
+++ b/content/ch05-subagents.md
@@ -140,7 +140,7 @@ agent = create_deep_agent(
             "system_prompt": "你是一个通用助手。",
             "tools": [internet_search],
             "model": ChatOpenAI(  # 子 Agent 用更强的模型
-                model="Pro/zai-org/GLM-5",
+                model="Pro/zai-org/GLM-5.1",
                 api_key=os.environ["SILICONFLOW_API_KEY"],
                 base_url="https://api.siliconflow.cn/v1",
             ),
@@ -197,7 +197,7 @@ from langchain_openai import ChatOpenAI
 from deepagents import create_deep_agent
 
 model = ChatOpenAI(
-    model="THUDM/glm-4-9b-chat",  # 免费模型，可替换为 "Pro/zai-org/GLM-5"
+    model="Qwen/Qwen2.5-7B-Instruct",  # 免费模型，可替换为 "Pro/zai-org/GLM-5.1"
     api_key=os.environ["SILICONFLOW_API_KEY"],
     base_url="https://api.siliconflow.cn/v1",
 )
@@ -331,7 +331,7 @@ subagents = [
         "description": "快速查询简单事实",
         "tools": [internet_search],
         "model": ChatOpenAI(  # 轻量快速模型
-            model="THUDM/glm-4-9b-chat",
+            model="Qwen/Qwen2.5-7B-Instruct",
             api_key=os.environ["SILICONFLOW_API_KEY"],
             base_url="https://api.siliconflow.cn/v1",
         ),
@@ -342,7 +342,7 @@ subagents = [
         "description": "执行需要深入推理的复杂分析任务",
         "tools": [internet_search, statistical_analysis],
         "model": ChatOpenAI(  # 强推理模型
-            model="Pro/zai-org/GLM-5",
+            model="Pro/zai-org/GLM-5.1",
             api_key=os.environ["SILICONFLOW_API_KEY"],
             base_url="https://api.siliconflow.cn/v1",
         ),


### PR DESCRIPTION
## 背景

- **#25**：`THUDM/glm-4-9b-chat` 在硅基流动平台已下线，课程默认示例无法跑通。
- **#24**：第二章首个 demo `from langchain_openai import ChatOpenAI`，但安装步骤只装了 `deepagents`，照着章节从头跑会报 `ModuleNotFoundError`。

本 PR 一并修复，并同步重新生成 ch02 讲义 PDF。

## 改动

### 模型替换（#25）— 按任务能力选择
- **轻量/简单示例**（ch02 快速上手、ch05 `quick-lookup` 轻量子 Agent）→ 免费 `Qwen/Qwen2.5-7B-Instruct`，改为 `MODEL_NAME` 环境变量配置（`os.environ.get(...)`），不再写死。
- **复杂示例**（ch04 任务规划 + `SummarizationMiddleware`、ch05 主协调 Agent + `deep-analyst` 子 Agent）→ SOTA 模型 `Pro/zai-org/GLM-5.1`。这些场景小模型往往**无法稳定跑通**，而非质量下降。
- **推荐模型表**刷新为当前 ID：`Pro/zai-org/GLM-5.1`、`Pro/moonshotai/Kimi-K2.6`、`Pro/deepseek-ai/DeepSeek-V4-Pro`、`Qwen/Qwen3.6-27B`（Qwen 系列置底）。
- ch02 新增“模型版本维护说明”，README 新增模型选择 `> [!NOTE]`。

### 依赖安装（#24）
- ch02 “安装 Deep Agents” 的 pip / uv / poetry 命令补上 `langchain-openai`，并说明本章通过 `ChatOpenAI` 接入模型。

### 讲义 PDF（#25）
- 重新生成 ch02 “推荐模型” 幻灯片（去掉旧模型，反映新阵容），重建 `public/pdfs/ch02.pdf`（10 页），本地 Ghostscript 压缩至 ~3 MiB，使 `assets:check` 通过。

## 验证

- `npm run build` 通过（11 页）；重新生成的内容无残留 `glm-4-9b-chat`，且首个示例安装命令含 `langchain-openai`。
- 已核查其他章节：仅 ch02 有“安装命令与导入不匹配”问题；ch07 的 `langchain-quickjs` 已有安装说明，其余章节沿用 ch02 环境。
- ch02.pdf 重渲染后 10 页、文字清晰。

## 备注

ch02 第 259 行的**图片 alt 文本**仍含旧模型名，因其描述图片 `06-comparison-api-interfaces.png` 的实际内容，需重新生成图片后再同步。

Closes #24
Closes #25
