### PR TITLE
docs: 改善第2章与准备篇文档表述

### DIFF
--- a/.github/ISSUE_TEMPLATE/02-code-issue.yml
+++ b/.github/ISSUE_TEMPLATE/02-code-issue.yml
@@ -6,13 +6,13 @@ body:
   - type: markdown
     attributes:
       value: |
-        遇到代码或环境问题别着急,按下面填清楚,我们和其他同学都能更快帮到你。💪
-        > 如果只是「不确定该怎么用」这类开放性问题,建议先去 [Discussions Q&A](https://github.com/datawhalechina/deepagents-in-action/discussions/categories/q-a) 提问。
+        遇到代码或环境问题别着急，按下面填清楚，我们和其他同学都能更快帮到你。💪
+        > 如果只是「不确定该怎么用」这类开放性问题，建议先去 [Discussions Q&A](https://github.com/datawhalechina/deepagents-in-action/discussions/categories/q-a) 提问。
   - type: dropdown
     id: chapter
     attributes:
       label: 所在章节
-      description: 哪一章的代码 / 示例?
+      description: 哪一章的代码 / 示例？
       options:
         - 准备篇（上）— AgentSeek CLI create
         - 准备篇（下）— AgentSeek CLI skills
@@ -31,7 +31,7 @@ body:
     id: problem
     attributes:
       label: 问题描述 / 复现步骤
-      description: 你做了什么、期望发生什么、实际发生了什么?最好能让我们照着复现
+      description: 你做了什么、期望发生什么、实际发生了什么？最好能让我们照着复现
       placeholder: |
         1. 运行 xxx
         2. 期望：……
@@ -42,7 +42,7 @@ body:
     id: logs
     attributes:
       label: 报错信息 / 日志
-      description: 把完整的报错堆栈贴进来(会自动按代码块渲染,无需手动加反引号)
+      description: 把完整的报错堆栈贴进来（会自动按代码块渲染，无需手动加反引号）
       render: shell
   - type: textarea
     id: env

--- a/.github/ISSUE_TEMPLATE/03-content-suggestion.yml
+++ b/.github/ISSUE_TEMPLATE/03-content-suggestion.yml
@@ -6,13 +6,13 @@ body:
   - type: markdown
     attributes:
       value: |
-        欢迎你为课程出谋划策!✨
-        > 涉及较大结构调整(如重写整章、新增篇章)的想法,建议先在 [Discussions Ideas](https://github.com/datawhalechina/deepagents-in-action/discussions/categories/ideas) 发起讨论,聊成熟了再开 Issue。
+        欢迎你为课程出谋划策！✨
+        > 涉及较大结构调整（如重写整章、新增篇章）的想法，建议先在 [Discussions Ideas](https://github.com/datawhalechina/deepagents-in-action/discussions/categories/ideas) 发起讨论，聊成熟了再开 Issue。
   - type: textarea
     id: suggestion
     attributes:
       label: 建议内容
-      description: 你希望补充什么主题、怎么调整,或哪里可以讲得更好?
+      description: 你希望补充什么主题、怎么调整，或哪里可以讲得更好？
       placeholder: 例如：希望在第 5 章补充一个多子 Agent 协作的完整示例……
     validations:
       required: true
@@ -20,7 +20,7 @@ body:
     id: rationale
     attributes:
       label: 理由 / 场景（选填）
-      description: 为什么需要这个改进?你在什么场景下遇到了困惑?
+      description: 为什么需要这个改进？你在什么场景下遇到了困惑？
   - type: checkboxes
     id: checks
     attributes:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,10 +43,12 @@ npm run dev
 
 ```
 content/
+├── pre01-agentseek-create.md
+├── pre02-agentseek-skills.md
 ├── ch01-agent-harness.md
 ├── ch02-quickstart.md
-├── ch03-virtual-filesystem.md
-└── ch04-task-planning.md
+├── ...
+└── ch08-long-term-memory.md
 ```
 
 **章节元数据**（标题、发布日期、视频链接）在 `scripts/chapters.json`。

--- a/content/ch02-quickstart.md
+++ b/content/ch02-quickstart.md
@@ -19,7 +19,7 @@ uv pip install deepagents langchain-openai
 poetry add deepagents langchain-openai
 ```
 
-Python 版本要求 3.10+。
+Python 版本要求 3.10+（最好>=3.11）。
 
 ### 配置 API Key
 

--- a/content/ch02-quickstart.md
+++ b/content/ch02-quickstart.md
@@ -19,7 +19,7 @@ uv pip install deepagents langchain-openai
 poetry add deepagents langchain-openai
 ```
 
-Python 版本要求 3.10+（最好>=3.11）。
+Python 版本要求 3.11+。
 
 ### 配置 API Key
 

--- a/content/pre02-agentseek-skills.md
+++ b/content/pre02-agentseek-skills.md
@@ -4,7 +4,7 @@
 
 在 AgentSeek 体系中，**Skill（技能）** 是一种教会 AI 编码助手如何执行特定任务的知识包。每个 Skill 是一个 `SKILL.md` 文件，包含经过验证的工程经验——当你在 Claude Code、Codex、Cursor 等工具中开发时，助手会自动读取并应用这些知识。
 
-目前我们给大家提供了两个核心技能：
+目前我们给大家重点提供了两个核心技能：
 
 - **`langchain-dev-guide`** — LangChain / LangGraph / DeepAgents 开发中的踩坑经验和解决方案（20+ 条）
 - **`langsmith-trace`** — 利用 LangSmith CLI 拉取和分析 Trace，帮助调试 Agent 执行流程


### PR DESCRIPTION
## Summary
- 更新 `CONTRIBUTING.md` 中过时的 `content/` 目录示例，补充准备篇并使用省略式展示当前章节结构
- 统一两个 GitHub Issue Template 中中文文案的标点格式
- 调整第 2 章 Python 版本说明，提示优先使用 Python 3.11+
- 优化 AgentSeek skills 章节中“两项核心技能”的表述，避免与完整技能列表存在的github-repo-cards产生冲突

## Why
这些修改属于贡献指南中欢迎的文档类贡献：
- 错别字 / 标点修正
- 表述改善
- 排版修复
- 事实性勘误

其中 Python 版本说明参考了 PyPI 上 `deepagents` 当前包信息：
https://pypi.org/project/deepagents/

## Checks

- [x] `git diff --check`
- [x] Issue Template YAML 解析检查