### PR TITLE
fix: 贡献者墙改用 commits API 取数，修复 Spr1ng7 丢失

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,13 @@ npx skills add ob-labs/agentseek --skill langsmith-trace
   <sub>49 commits</sub>
 </td>
 <td align="center" valign="top" width="104">
+  <a href="https://github.com/Spr1ng7" title="Spr1ng7">
+    <img src="https://avatars.githubusercontent.com/u/188573471?v=4&s=144" width="72" height="72" alt="Spr1ng7" style="border-radius:50%;" />
+  </a><br />
+  <a href="https://github.com/Spr1ng7" title="打开 Spr1ng7 的 GitHub 主页"><kbd><strong>Spr1ng7</strong></kbd></a><br />
+  <sub>5 commits</sub>
+</td>
+<td align="center" valign="top" width="104">
   <a href="https://github.com/knqiufan" title="knqiufan">
     <img src="https://avatars.githubusercontent.com/u/34114995?v=4&s=144" width="72" height="72" alt="knqiufan" style="border-radius:50%;" />
   </a><br />
@@ -142,6 +149,15 @@ npx skills add ob-labs/agentseek --skill langsmith-trace
     <img src="https://avatars.githubusercontent.com/u/56186222?v=4&s=144" width="72" height="72" alt="Walt-like" style="border-radius:50%;" />
   </a><br />
   <a href="https://github.com/Walt-like" title="打开 Walt-like 的 GitHub 主页"><kbd><strong>Walt-like</strong></kbd></a><br />
+  <sub>1 commit</sub>
+</td>
+</tr>
+<tr>
+<td align="center" valign="top" width="104">
+  <a href="https://github.com/xschen-beb" title="xschen-beb">
+    <img src="https://avatars.githubusercontent.com/u/61721839?v=4&s=144" width="72" height="72" alt="xschen-beb" style="border-radius:50%;" />
+  </a><br />
+  <a href="https://github.com/xschen-beb" title="打开 xschen-beb 的 GitHub 主页"><kbd><strong>xschen-beb</strong></kbd></a><br />
   <sub>1 commit</sub>
 </td>
 </tr>

--- a/scripts/update-contributors.mjs
+++ b/scripts/update-contributors.mjs
@@ -27,6 +27,11 @@ function resolveRepoSlug() {
   return match[1];
 }
 
+// Aggregate contributors from the commits API rather than the /contributors
+// stats endpoint. The latter is cached/eventually-consistent: after pushes it
+// can return a transitional snapshot that omits real contributors or surfaces
+// bots, which would silently drop people from the wall. Tallying commit authors
+// is authoritative and real-time.
 async function fetchContributors(repoSlug) {
   const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
   const headers = {
@@ -38,11 +43,11 @@ async function fetchContributors(repoSlug) {
     headers.Authorization = `Bearer ${token}`;
   }
 
-  const contributors = [];
+  const byLogin = new Map();
   let page = 1;
 
   while (true) {
-    const url = `https://api.github.com/repos/${repoSlug}/contributors?per_page=100&page=${page}`;
+    const url = `https://api.github.com/repos/${repoSlug}/commits?per_page=100&page=${page}`;
     const response = await fetch(url, { headers });
 
     if (!response.ok) {
@@ -55,19 +60,32 @@ async function fetchContributors(repoSlug) {
       break;
     }
 
-    contributors.push(...pageItems);
+    for (const commit of pageItems) {
+      const author = commit?.author;
+      // Skip commits with no linked GitHub user (e.g. unmatched email) and bots.
+      if (!author?.login || author.type !== 'User') {
+        continue;
+      }
+
+      const existing = byLogin.get(author.login);
+      if (existing) {
+        existing.contributions += 1;
+      } else {
+        byLogin.set(author.login, {
+          login: author.login,
+          profileUrl: author.html_url,
+          avatarUrl: `${author.avatar_url}&s=144`,
+          contributions: 1,
+        });
+      }
+    }
+
     page += 1;
   }
 
-  return contributors
-    .filter((item) => item?.type === 'User' && item?.login)
-    .map((item) => ({
-      login: item.login,
-      profileUrl: item.html_url,
-      avatarUrl: `${item.avatar_url}&s=144`,
-      contributions: item.contributions ?? 0,
-    }))
-    .sort((a, b) => b.contributions - a.contributions || a.login.localeCompare(b.login));
+  return [...byLogin.values()].sort(
+    (a, b) => b.contributions - a.contributions || a.login.localeCompare(b.login),
+  );
 }
 
 function updateReadme(wallMarkup) {


### PR DESCRIPTION
## 问题

合并 PR #28 / #29 / #30 后，贡献者墙自动更新时**丢失了 Spr1ng7**（实际有 5 个提交，是仅次于 webup 的第二多贡献者），同时一度把 `github-actions[bot]` 也算了进来。

## 原因

`scripts/update-contributors.mjs` 原先从 GitHub 的 `/contributors` 统计接口取数据。这个接口是**缓存且最终一致**的：push 之后它会返回一个过渡态快照，可能漏掉真实贡献者、也可能混入 bot。贡献者墙基于这个坏快照重新生成，于是 Spr1ng7 被静默删掉了。

我用 commit 作者聚合做了核对，确认 Spr1ng7 在 main 上确有 5 个提交（`#20`、`#21`、`#28`、`#29`、`#30`），数据本身没问题，是统计接口的快照坏了。

## 改动

改为从 `/commits` 接口聚合提交作者来统计贡献者——这是**权威且实时**的来源：

- 按 `author.login` 累加每位作者的提交数。
- 通过 `author.type === "User"` + `author.login` 兜底，跳过 bot 以及邮箱未匹配到 GitHub 账号的提交。
- 排序规则不变（提交数降序，同数按 login 字母序）。

重新生成的 README 已恢复 Spr1ng7（5 个提交），并补上 xschen-beb（#34，已合并）。

## 验证

- `node --test scripts/update-contributors.test.mjs` 通过。
- `npm run build` 通过。
- 用真实 API 跑了一遍脚本，输出 9 位真实贡献者、无 bot、Spr1ng7 正常在列。
