### PR TITLE
fix: 贡献者墙用户名统一单行显示(不换行连字符)

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ npx skills add ob-labs/agentseek --skill langsmith-trace
   <a href="https://github.com/Walt-like" title="Walt-like">
     <img src="https://avatars.githubusercontent.com/u/56186222?v=4&s=144" width="72" height="72" alt="Walt-like" style="border-radius:50%;" />
   </a><br />
-  <a href="https://github.com/Walt-like" title="打开 Walt-like 的 GitHub 主页"><kbd><strong>Walt-like</strong></kbd></a><br />
+  <a href="https://github.com/Walt-like" title="打开 Walt-like 的 GitHub 主页"><kbd><strong>Walt‑like</strong></kbd></a><br />
   <sub>1 commit</sub>
 </td>
 </tr>
@@ -157,7 +157,7 @@ npx skills add ob-labs/agentseek --skill langsmith-trace
   <a href="https://github.com/xschen-beb" title="xschen-beb">
     <img src="https://avatars.githubusercontent.com/u/61721839?v=4&s=144" width="72" height="72" alt="xschen-beb" style="border-radius:50%;" />
   </a><br />
-  <a href="https://github.com/xschen-beb" title="打开 xschen-beb 的 GitHub 主页"><kbd><strong>xschen-beb</strong></kbd></a><br />
+  <a href="https://github.com/xschen-beb" title="打开 xschen-beb 的 GitHub 主页"><kbd><strong>xschen‑beb</strong></kbd></a><br />
   <sub>1 commit</sub>
 </td>
 </tr>

--- a/scripts/contributor-wall.mjs
+++ b/scripts/contributor-wall.mjs
@@ -15,12 +15,19 @@ export function buildWall(contributors) {
       ? `${contributor.login.slice(0, 11)}…`
       : contributor.login;
 
+    // GitHub's README sanitizer strips style/class from <kbd>, so CSS
+    // (white-space/text-overflow) can't keep names on one line. Instead make
+    // the displayed name non-breaking so hyphens/spaces don't wrap the keycap
+    // (e.g. "xschen-beb"): U+2011 non-breaking hyphen + &nbsp;. Truncation
+    // above is then the single, uniform overflow rule.
+    const noWrapLogin = displayedLogin.replace(/-/g, '‑').replace(/ /g, '&nbsp;');
+
     return [
       '<td align="center" valign="top" width="104">',
       `  <a href="${contributor.profileUrl}" title="${contributor.login}">`,
       `    <img src="${contributor.avatarUrl}" width="72" height="72" alt="${contributor.login}" style="border-radius:50%;" />`,
       '  </a><br />',
-      `  <a href="${contributor.profileUrl}" title="打开 ${contributor.login} 的 GitHub 主页"><kbd><strong>${displayedLogin}</strong></kbd></a><br />`,
+      `  <a href="${contributor.profileUrl}" title="打开 ${contributor.login} 的 GitHub 主页"><kbd><strong>${noWrapLogin}</strong></kbd></a><br />`,
       `  <sub>${contributor.contributions} commit${contributor.contributions === 1 ? '' : 's'}</sub>`,
       '</td>',
     ].join('\n');

--- a/scripts/update-contributors.test.mjs
+++ b/scripts/update-contributors.test.mjs
@@ -10,7 +10,13 @@ const contributors = [
     avatarUrl: 'https://avatars.githubusercontent.com/u/3906539?v=4&s=144',
     contributions: 1,
   },
-  ...Array.from({ length: 7 }, (_, index) => ({
+  {
+    login: 'xschen-beb',
+    profileUrl: 'https://github.com/xschen-beb',
+    avatarUrl: 'https://avatars.githubusercontent.com/u/61721839?v=4&s=144',
+    contributions: 1,
+  },
+  ...Array.from({ length: 6 }, (_, index) => ({
     login: `user${index}`,
     profileUrl: `https://github.com/user${index}`,
     avatarUrl: `https://avatars.githubusercontent.com/u/${index}?v=4&s=144`,
@@ -33,4 +39,14 @@ test('builds eight equal columns with abbreviated clickable keycap names', () =>
   );
   assert.doesNotMatch(wall, /主页 ↗/);
   assert.doesNotMatch(wall, /<samp>|&#160;/);
+});
+
+test('keeps hyphenated names on one line via a non-breaking hyphen', () => {
+  const wall = buildWall(contributors);
+
+  // Displayed keycap uses U+2011 (non-breaking hyphen), not ASCII "-".
+  assert.match(wall, /<kbd><strong>xschen‑beb<\/strong><\/kbd>/);
+  // ...while the title/href/alt keep the real ASCII login intact.
+  assert.match(wall, /title="xschen-beb"/);
+  assert.match(wall, /href="https:\/\/github\.com\/xschen-beb"/);
 });


### PR DESCRIPTION
## 问题

贡献者墙的用户名溢出处理不统一(见下图)：长用户名会被截断成 `codeMonkeyW…`，但带连字符的 `xschen-beb` 却换行成了两行——因为连字符 `-` 是浏览器的换行点。

## 为什么不用 CSS

GitHub 的 README 渲染会**过滤掉 `<kbd>` 等元素上的 `style` / `class`**(实测只有 `<img>` 的 style 会被保留并重写)。所以 `white-space: nowrap` / `text-overflow: ellipsis` 这类 CSS 在 README 里根本不生效——这也是原作者当初用 JS 截断的原因。

## 改动

在**展示用**的用户名里，把会触发换行的字符替换成不换行版本：

- 连字符 `-` → U+2011 不换行连字符 `‑`
- 空格 → `&nbsp;`

这样每个 keycap 都保持单行，`>11` 字符的截断成为唯一且统一的溢出规则。`title` / `href` / `alt` 里仍保留**完整真实的 login**(含原始 `-`)，跳转和可访问性不受影响。

效果：

```
xschen-beb     -> xschen‑beb   (单行,不换行)
Walt-like      -> Walt‑like    (单行)
codeMonkeyWang -> codeMonkeyW… (截断)
```

## 验证

- `node --test scripts/update-contributors.test.mjs` 通过(新增一条断言：连字符名用 U+2011，且 title/href 保留 ASCII login)。
- `npm run build` 通过。
- 用真实 API 重新生成 README，确认 `Walt‑like` / `xschen‑beb` 均为单行。


