### PR TITLE
fix:  修正第3章 括号后 Markdown 加粗失效问题

### DIFF
--- a/content/ch03-virtual-filesystem.md
+++ b/content/ch03-virtual-filesystem.md
@@ -119,7 +119,7 @@ grep("def create_agent", output_mode="content", context=3)
 
 ## 可插拔的存储后端
 
-到目前为止我们讨论的"虚拟文件系统"是一个抽象概念。具体的文件存到哪里，由**后端（Backend）**决定。
+到目前为止我们讨论的"虚拟文件系统"是一个抽象概念。具体的文件存到哪里，由<strong>后端（Backend）</strong>决定。
 
 Deep Agents 的后端是**可插拔的**——你可以根据场景选择不同的存储策略。
 

--- a/content/ch04-task-planning.md
+++ b/content/ch04-task-planning.md
@@ -114,7 +114,7 @@ Agent 调用 write_todos 更新列表：
 
 到目前为止，我们一直从 Deep Agents 的视角看 `write_todos`——"调用 `create_deep_agent()` 就自动有了"。但如果你想真正理解这个能力是**怎么实现的**，以及将来**如何自己扩展**，就需要揭开引擎盖，看看底层的 LangChain 中间件机制。
 
-还记得第 1 章的三层架构吗？Deep Agents（Harness）构建在 LangChain（Framework）之上。而 LangChain 提供了一套**中间件（Middleware）**系统——它是 Agent 能力的插件机制。`create_deep_agent()` 内部做的事情，本质上就是把一组中间件**自动组装**到了 Agent 上。
+还记得第 1 章的三层架构吗？Deep Agents（Harness）构建在 LangChain（Framework）之上。而 LangChain 提供了一套<strong>中间件（Middleware）</strong>系统——它是 Agent 能力的插件机制。`create_deep_agent()` 内部做的事情，本质上就是把一组中间件**自动组装**到了 Agent 上。
 
 `create_deep_agent()` 的中间件堆栈分为三层：
 


### PR DESCRIPTION
将受影响的加粗写法替换为内联 HTML 标签：
- 原：`**后端（Backend）**`
- 改为：`<strong>后端（Backend）</strong>`