### PR TITLE
feat: 文章页加目录侧栏，首页移除侧栏

### DIFF
--- a/src/components/ChapterRail.astro
+++ b/src/components/ChapterRail.astro
@@ -15,7 +15,8 @@ const { sections } = Astro.props;
 const base = import.meta.env.BASE_URL;
 ---
 
-{/* Mobile/tablet (<lg): sticky bar + tap-to-open dropdown. */}
+{/* Mobile/tablet (<lg): sticky bar + tap-to-open dropdown. Desktop shows nothing —
+    on wide screens the chapter cards take main's full width. */}
 <div class="chapter-rail-mobile lg:hidden" data-rail-mobile>
   <button
     type="button"
@@ -51,31 +52,7 @@ const base = import.meta.env.BASE_URL;
   </div>
 </div>
 
-{/* Desktop rail: quiet, sticky, lg+ only. */}
-<nav class="chapter-rail hidden lg:block lg:mt-16 sticky top-24 max-h-[calc(100vh-7rem)] overflow-y-auto" aria-label="课程目录">
-  <p class="text-[10px] font-mono uppercase tracking-[0.15em] text-ink-muted/35 mb-3">目录</p>
-  {sections.map(group => (
-    <div class="mb-5 last:mb-0">
-      <p class="text-[11px] font-semibold tracking-wide text-ink-muted/75 mb-1.5">{group.section}</p>
-      <ul class="space-y-1">
-        {group.items.map(item => (
-          <li>
-            <a
-              href={`${base}/#ch-${item.id}`}
-              data-rail-target={`ch-${item.id}`}
-              title={item.title}
-              class="rail-link block truncate py-1.5 pl-3 text-[13px] leading-snug text-ink-muted/65 hover:text-ink transition-colors"
-            >{item.title}</a>
-          </li>
-        ))}
-      </ul>
-    </div>
-  ))}
-</nav>
-
 <style>
-  /* Active item (set by scrollspy JS in Task 5): firm the text + a single 1px gold tick.
-     This is the only color in the rail. No background, no bold gold text. */
   .rail-link {
     border-left: 2px solid transparent;
     margin-left: -2px; /* keep text aligned whether or not the tick shows */
@@ -117,34 +94,11 @@ const base = import.meta.env.BASE_URL;
     background: var(--color-gold-pale);
     border-radius: 2px;
   }
-
-  @media (min-width: 1600px) {
-    /* Detach the rail into the viewport's left gutter without disturbing the
-       cards. It stays in normal document order as the first child of
-       .chapter-grid (now display:block), so its TOP naturally begins at the
-       grid/body start, below the hero — not pinned to the viewport top.
-       sticky keeps it scroll-following; the float + negative right margin
-       cancel its horizontal footprint so the cards keep main's full width and
-       are not pushed down. The negative left margin pulls it from main's
-       content-left edge out to ~1.5rem from the viewport edge:
-         main content-left = (100vw - 72rem)/2 + 1.5rem (max-w-6xl + px-6)
-         want rail-left     = 1.5rem  ->  margin-left = -((100vw - 72rem)/2) */
-    .chapter-rail {
-      position: sticky;
-      top: 6rem;
-      float: left;
-      width: 192px;
-      margin-top: 0; /* drop lg:mt-16 so the rail top lines up with the cards */
-      margin-left: calc(-1 * (100vw - 72rem) / 2);
-      margin-right: -192px;
-      max-height: calc(100vh - 7rem);
-      overflow-y: auto;
-    }
-  }
 </style>
 
 <script>
-  // Scrollspy: highlight the rail item whose card is nearest the top of the viewport.
+  // Scrollspy for the mobile course-directory bar: highlight the rail item whose
+  // card is nearest the top of the viewport and reflect its section in the bar.
   // Rail links carry data-rail-target="ch-<id>"; cards have id="ch-<id>".
   let prevObserver: IntersectionObserver | undefined;
   let railCurrentLabel: HTMLElement | null = null;
@@ -156,7 +110,7 @@ const base = import.meta.env.BASE_URL;
     if (prevDocClickHandler) document.removeEventListener('click', prevDocClickHandler);
     if (prevDocKeydownHandler) document.removeEventListener('keydown', prevDocKeydownHandler);
     const links = Array.from(
-      document.querySelectorAll<HTMLAnchorElement>('.chapter-rail .rail-link[data-rail-target]')
+      document.querySelectorAll<HTMLAnchorElement>('[data-rail-mobile] .rail-link[data-rail-target]')
     );
     if (links.length === 0) return;
 
@@ -166,8 +120,8 @@ const base = import.meta.env.BASE_URL;
       if (t) linkByTarget.set(t, link);
     }
 
-    const cards = links
-      .map((l) => document.getElementById(l.dataset.railTarget!))
+    const cards = Array.from(linkByTarget.keys())
+      .map((id) => document.getElementById(id))
       .filter((el): el is HTMLElement => el !== null);
     if (cards.length === 0) return;
 
@@ -187,8 +141,6 @@ const base = import.meta.env.BASE_URL;
       if (active) {
         active.classList.add('is-active');
         active.setAttribute('aria-current', 'true');
-        // Keep the active item visible if the rail itself scrolled.
-        active.scrollIntoView({ block: 'nearest' });
       }
     };
 

--- a/src/components/ContentsRail.astro
+++ b/src/components/ContentsRail.astro
@@ -1,0 +1,263 @@
+---
+interface Heading {
+  depth: number;
+  slug: string;
+  text: string;
+}
+interface Props {
+  headings: Heading[];
+}
+
+const { headings } = Astro.props;
+// Only H2/H3 make a useful contents rail; deeper levels add noise.
+const items = headings.filter(h => h.depth === 2 || h.depth === 3);
+---
+
+{items.length > 0 && (
+  <>
+    {/* Mobile/tablet: sticky bar + tap-to-open dropdown. Hidden once the
+        viewport is wide enough for the gutter rail (see @media below). */}
+    <div class="contents-rail-mobile" data-contents-mobile>
+      <button
+        type="button"
+        class="contents-rail-mobile__bar"
+        aria-expanded="false"
+        aria-controls="contents-rail-panel"
+        data-contents-toggle
+      >
+        <span class="inline-flex items-center gap-2">
+          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h12M4 18h8"/></svg>
+          <span class="text-sm font-medium">本页目录</span>
+        </span>
+        <span class="text-xs text-ink-muted/60 truncate max-w-[55%]" data-contents-current></span>
+      </button>
+      <div id="contents-rail-panel" class="contents-rail-mobile__panel" hidden>
+        <ul class="space-y-0.5">
+          {items.map(h => (
+            <li>
+              <a
+                href={`#${h.slug}`}
+                data-toc-target={h.slug}
+                title={h.text}
+                class={`toc-link block truncate py-1.5 text-[13px] text-ink-muted/70 hover:text-ink transition-colors ${h.depth === 3 ? 'pl-6' : 'pl-3'}`}
+              >{h.text}</a>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+
+    {/* Desktop rail: quiet, sticky. Floated into the article's right gutter;
+        only shown when the viewport is wide enough to hold it (see @media). */}
+    <nav class="contents-rail sticky top-24 max-h-[calc(100vh-7rem)] overflow-y-auto" aria-label="本页目录">
+      <p class="text-[10px] font-mono uppercase tracking-[0.15em] text-ink-muted/35 mb-3">本页目录</p>
+      <ul class="space-y-1">
+        {items.map(h => (
+          <li>
+            <a
+              href={`#${h.slug}`}
+              data-toc-target={h.slug}
+              title={h.text}
+              class={`toc-link block truncate py-1.5 text-[13px] leading-snug text-ink-muted/65 hover:text-ink transition-colors ${h.depth === 3 ? 'pl-6' : 'pl-3'}`}
+            >{h.text}</a>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  </>
+)}
+
+<style>
+  .toc-link {
+    border-left: 2px solid transparent;
+    margin-left: -2px; /* keep text aligned whether or not the tick shows */
+  }
+  .toc-link.is-active {
+    color: var(--color-ink);
+    border-left-color: var(--color-gold);
+  }
+  .toc-link:focus-visible {
+    outline: none;
+    color: var(--color-ink);
+    border-left-color: var(--color-gold);
+    background: var(--color-gold-pale);
+    border-radius: 2px;
+  }
+  .contents-rail-mobile {
+    position: sticky;
+    top: 0;
+    z-index: 30;
+    margin: 0 -1.5rem 1.5rem; /* bleed to viewport edges (counteract article px-6) */
+    background: var(--color-paper);
+    border-bottom: 1px solid var(--color-gold-pale);
+  }
+  .contents-rail-mobile__bar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+    padding: 0.75rem 1.5rem;
+    color: var(--color-ink);
+    background: transparent;
+    border: none;
+    cursor: pointer;
+  }
+  .contents-rail-mobile__panel {
+    max-height: 60vh;
+    overflow-y: auto;
+    padding: 0.5rem 1.5rem 1rem;
+    border-top: 1px solid var(--color-gold-pale);
+  }
+
+  /* Default (narrow): the gutter rail is hidden; only the mobile bar shows. */
+  .contents-rail { display: none; }
+
+  /* Wide enough for a real right gutter beside the max-w-3xl (48rem) article:
+       gutter each side = (100vw - 48rem) / 2
+     A 192px rail + breathing room needs ~1280px before it's worth detaching.
+     Float it into the right gutter (negative margin cancels its horizontal
+     footprint so the centered article column is undisturbed) and drop the
+     mobile bar. The rail lives at the top of <article> in document order, so
+     it floats alongside the header + prose that follow it.
+       article right edge from viewport-right = (100vw - 48rem) / 2
+       float-right inner edge adds the 1.5rem px-6 padding
+       margin-right = -((100vw - 48rem) / 2) pulls it to ~1.5rem from the edge */
+  @media (min-width: 1280px) {
+    .contents-rail-mobile { display: none; }
+    .contents-rail {
+      display: block;
+      float: right;
+      width: 192px;
+      margin-right: calc(-1 * (100vw - 48rem) / 2);
+      margin-left: -192px; /* cancel the float's footprint so prose keeps full width */
+      margin-top: 4rem; /* clear the article header's top padding */
+    }
+  }
+</style>
+
+<script>
+  // Scrollspy for the article contents rail: highlight the TOC item whose
+  // heading is nearest the top of the viewport. TOC links carry
+  // data-toc-target="<slug>"; headings render with matching id="<slug>".
+  let prevObserver: IntersectionObserver | undefined;
+  let prevDocClickHandler: ((e: MouseEvent) => void) | undefined;
+  let prevDocKeydownHandler: ((e: KeyboardEvent) => void) | undefined;
+  function initContentsRail() {
+    prevObserver?.disconnect();
+    if (prevDocClickHandler) document.removeEventListener('click', prevDocClickHandler);
+    if (prevDocKeydownHandler) document.removeEventListener('keydown', prevDocKeydownHandler);
+
+    const links = Array.from(
+      document.querySelectorAll<HTMLAnchorElement>('.toc-link[data-toc-target]')
+    );
+    if (links.length === 0) return;
+
+    // Group links by target slug (the same heading appears in both the desktop
+    // rail and the mobile panel), so activating a slug lights up both.
+    const linksByTarget = new Map<string, HTMLAnchorElement[]>();
+    for (const link of links) {
+      const t = link.dataset.tocTarget;
+      if (!t) continue;
+      const list = linksByTarget.get(t) ?? [];
+      list.push(link);
+      linksByTarget.set(t, list);
+    }
+
+    const headings = Array.from(linksByTarget.keys())
+      .map((slug) => document.getElementById(slug))
+      .filter((el): el is HTMLElement => el !== null);
+    if (headings.length === 0) return;
+
+    const currentLabel = document.querySelector<HTMLElement>('[data-contents-current]');
+    const textOf = (slug: string) =>
+      linksByTarget.get(slug)?.[0]?.textContent?.trim() ?? '';
+
+    let activeId = '';
+    const setActive = (id: string) => {
+      if (id === activeId) return;
+      activeId = id;
+      if (currentLabel) currentLabel.textContent = textOf(id);
+      for (const link of links) {
+        link.classList.remove('is-active');
+        link.removeAttribute('aria-current');
+      }
+      for (const link of linksByTarget.get(id) ?? []) {
+        link.classList.add('is-active');
+        link.setAttribute('aria-current', 'true');
+        link.scrollIntoView({ block: 'nearest' });
+      }
+    };
+
+    const visible = new Set<string>();
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) visible.add(entry.target.id);
+          else visible.delete(entry.target.id);
+        }
+        let topId = '';
+        let topY = Infinity;
+        for (const id of visible) {
+          const el = document.getElementById(id);
+          if (!el) continue;
+          const y = el.getBoundingClientRect().top;
+          if (y < topY) {
+            topY = y;
+            topId = id;
+          }
+        }
+        if (topId) setActive(topId);
+      },
+      { rootMargin: '-20% 0px -70% 0px', threshold: 0 }
+    );
+
+    for (const h of headings) observer.observe(h);
+    prevObserver = observer;
+
+    // --- Mobile bar: toggle panel ---
+    const mobile = document.querySelector<HTMLElement>('[data-contents-mobile]');
+    const toggle = document.querySelector<HTMLButtonElement>('[data-contents-toggle]');
+    const panel = document.getElementById('contents-rail-panel');
+
+    const closePanel = () => {
+      if (!toggle || !panel) return;
+      toggle.setAttribute('aria-expanded', 'false');
+      panel.hidden = true;
+    };
+    const openPanel = () => {
+      if (!toggle || !panel) return;
+      toggle.setAttribute('aria-expanded', 'true');
+      panel.hidden = false;
+    };
+
+    if (toggle && panel) {
+      toggle.addEventListener('click', () => {
+        if (panel.hidden) openPanel();
+        else closePanel();
+      });
+      panel.querySelectorAll('a[data-toc-target]').forEach((a) =>
+        a.addEventListener('click', () => closePanel())
+      );
+      const clickHandler = (e: MouseEvent) => {
+        if (!mobile) return;
+        if (!panel.hidden && !mobile.contains(e.target as Node)) closePanel();
+      };
+      const keydownHandler = (e: KeyboardEvent) => {
+        if (e.key === 'Escape' && !panel.hidden) closePanel();
+      };
+      document.addEventListener('click', clickHandler);
+      document.addEventListener('keydown', keydownHandler);
+      prevDocClickHandler = clickHandler;
+      prevDocKeydownHandler = keydownHandler;
+    }
+
+    // Seed the mobile bar label so it's never blank before scrollspy fires.
+    if (currentLabel && !currentLabel.textContent) {
+      const first = linksByTarget.keys().next().value;
+      if (first) currentLabel.textContent = textOf(first);
+    }
+  }
+
+  initContentsRail();
+  document.addEventListener('astro:page-load', initContentsRail);
+</script>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -17,7 +17,7 @@ const base = import.meta.env.BASE_URL;
         <path d="M92 70L78 87" stroke="#b8860b" stroke-width="2" stroke-linecap="round" class="group-hover:stroke-[#d4a853] transition-colors"/>
         <path d="M50 92H78" stroke="#b8860b" stroke-width="2" stroke-linecap="round" class="group-hover:stroke-[#d4a853] transition-colors"/>
       </svg>
-      <span class="font-sans font-medium text-sm text-ink-muted tracking-wide hidden sm:inline group-hover:text-gold transition-colors">Deep Agents 实战</span>
+      <span class="font-sans font-medium text-sm text-ink-muted tracking-wide group-hover:text-gold transition-colors">Deep Agents 实战</span>
     </a>
     <a href="https://github.com/datawhalechina/deepagents-in-action" target="_blank" rel="noopener" class="flex items-center gap-1.5 text-xs text-ink-muted/50 font-mono tracking-wider hover:text-ink-muted transition-colors group" aria-label="GitHub">
       <svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"/></svg>

--- a/src/layouts/ChapterLayout.astro
+++ b/src/layouts/ChapterLayout.astro
@@ -6,6 +6,7 @@ import Prose from '../components/Prose.astro';
 import PdfDownload from '../components/PdfDownload.astro';
 import SocialLinks from '../components/SocialLinks.astro';
 import ChapterNav from '../components/ChapterNav.astro';
+import ContentsRail from '../components/ContentsRail.astro';
 
 interface Props {
   title: string;
@@ -16,11 +17,12 @@ interface Props {
   bilibili?: string;
   xhs?: string;
   chapterId?: string;
+  headings?: Array<{ depth: number; slug: string; text: string }>;
   prev?: { id: string; title: string; chapter: number } | null;
   next?: { id: string; title: string; chapter: number } | null;
 }
 
-const { title, chapter, section, description, slides, bilibili, xhs, chapterId, prev, next } = Astro.props;
+const { title, chapter, section, description, slides, bilibili, xhs, chapterId, headings = [], prev, next } = Astro.props;
 const CONTENT_REPO = 'https://github.com/datawhalechina/deepagents-in-action';
 const editUrl = chapterId ? `${CONTENT_REPO}/blob/main/content/${chapterId}.md` : `${CONTENT_REPO}/tree/main/content`;
 
@@ -38,6 +40,7 @@ const isExtra = section === '准备篇';
 <BaseLayout title={`${isExtra ? '' : `第 ${chapter} 章：`}${title} — Deep Agents 实战`} description={description}>
   <Header />
   <article class="max-w-3xl mx-auto px-6 py-16">
+    <ContentsRail headings={headings} />
     <header class="mb-14 relative">
       <div class="flex items-center gap-3 mb-6">
         <span class={`inline-block text-[10px] font-mono font-medium tracking-wider px-2.5 py-1 rounded ${tagClass}`}>

--- a/src/pages/chapters/[...slug].astro
+++ b/src/pages/chapters/[...slug].astro
@@ -22,7 +22,7 @@ export async function getStaticPaths() {
 }
 
 const { chapter, prev, next } = Astro.props;
-const { Content } = await render(chapter);
+const { Content, headings } = await render(chapter);
 ---
 
 <ChapterLayout
@@ -34,6 +34,7 @@ const { Content } = await render(chapter);
   bilibili={chapter.data.bilibili || chapter.data.slides?.[0]?.bilibili}
   xhs={chapter.data.xhs || chapter.data.slides?.[0]?.xhs}
   chapterId={chapter.id}
+  headings={headings}
   prev={prev}
   next={next}
 >

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -130,9 +130,8 @@ try {
       </div>
     </section>
 
-    <div class="chapter-grid lg:grid lg:grid-cols-[220px_minmax(0,1fr)] lg:gap-12 lg:items-start">
-      <ChapterRail sections={railSections} />
-      <div class="min-w-0">
+    <ChapterRail sections={railSections} />
+    <div class="min-w-0">
     <!-- Chapter list by section -->
     {grouped.map(({ section, chapters }) => {
       const hasPublished = chapters.some(ch => ch.data.published);
@@ -206,20 +205,9 @@ try {
       ) : null;
     })}
       </div>
-    </div>
   </main>
   <Footer />
 </BaseLayout>
-
-<style>
-  /* On wide screens the rail detaches into the left gutter so the chapter
-     cards recenter to main's full width (aligned with the centered hero).
-     Below this width there isn't enough gutter, so the grid keeps its
-     default 220px squeeze-in column (see lg: classes on .chapter-grid). */
-  @media (min-width: 1600px) {
-    .chapter-grid { display: block; }
-  }
-</style>
 
 
 <script>


### PR DESCRIPTION
## 改动

### 首页
- 移除桌面端章节侧栏(side rail)及其两栏网格,Hero 与章节卡片恢复整页居中宽度。
- 保留移动端「课程目录」下拉条。

### 文章页
- 新增「本页目录」内容侧栏(`ContentsRail.astro`),列出 H2 + H3:
  - 宽屏(≥1280px):安静的 sticky TOC,浮入右侧留白区,带滚动高亮(scrollspy)。
  - 窄屏:折叠为顶部 sticky 下拉条,展示当前小节。
- 锚点来自 Astro `render()` 的 headings,与自动生成的标题 id 一致。

### Header
- 移动端始终显示「Deep Agents 实战」文字标识(原先仅图标),让返回首页的入口更易识别。

## 验证
- `npm run build` 通过(11 页)。
- 浏览器实测桌面(1440px)与移动(390px):侧栏定位、滚动高亮、锚点跳转、移动下拉、Header 均正常。