### PR TITLE
docs: 补充 pre01 配置要点中关于使用其他模型的说明

### DIFF
--- a/content/pre01-agentseek-create.md
+++ b/content/pre01-agentseek-create.md
@@ -226,7 +226,7 @@ LANGSMITH_API_KEY=<your-langsmith-key>
 
 ### 配置要点
 
-- **模型供应商**：设置 `AGENTSEEK_MODEL_PROVIDER` 和 `AGENTSEEK_MODEL`，选择一个供应商填写对应 API Key 即可。国内用户推荐使用通义千问（DashScope）。
+- **模型供应商**：设置 `AGENTSEEK_MODEL_PROVIDER` 和 `AGENTSEEK_MODEL`，选择一个供应商填写对应 API Key 即可。国内用户推荐使用通义千问（DashScope）。使用其他模型时只需修改 `AGENTSEEK_MODEL_PROVIDER`、`AGENTSEEK_MODEL`、`OPENAI_API_BASE`和`OPENAI_API_KEY`,`AGENTSEEK_MODEL_PROVIDER`国内模型一般选择`openai`或者`anthropic`,`AGENTSEEK_MODEL`填写你所使用的模型名称，`OPENAI_API_BASE`根据选择的模型提供商填写对应的baseurl，`OPENAI_API_KEY`这里填写API key。
 - **Tavily 搜索 Key**：`deepagents/research` 模板需要网络搜索，在 [app.tavily.com](https://app.tavily.com/) 获取免费 Key。
 - **LangSmith Tracing**（强烈推荐）：在 [smith.langchain.com](https://smith.langchain.com/) 注册后，进入 Settings → API Keys 创建 Token 填入即可。个人用户每月 5000 次免费 Trace 额度。
 

--- a/content/pre01-agentseek-create.md
+++ b/content/pre01-agentseek-create.md
@@ -226,7 +226,7 @@ LANGSMITH_API_KEY=<your-langsmith-key>
 
 ### 配置要点
 
-- **模型供应商**：设置 `AGENTSEEK_MODEL_PROVIDER` 和 `AGENTSEEK_MODEL`，选择一个供应商填写对应 API Key 即可。国内用户推荐使用通义千问（DashScope）。使用其他模型时只需修改 `AGENTSEEK_MODEL_PROVIDER`、`AGENTSEEK_MODEL`、`OPENAI_API_BASE`和`OPENAI_API_KEY`,`AGENTSEEK_MODEL_PROVIDER`国内模型一般选择`openai`或者`anthropic`,`AGENTSEEK_MODEL`填写你所使用的模型名称，`OPENAI_API_BASE`根据选择的模型提供商填写对应的baseurl，`OPENAI_API_KEY`这里填写API key。
+- **模型供应商**：设置 `AGENTSEEK_MODEL_PROVIDER` 和 `AGENTSEEK_MODEL`，选择一个供应商填写对应 API Key 即可。国内用户推荐使用通义千问（DashScope）。使用其他模型时只需修改 `AGENTSEEK_MODEL_PROVIDER`、`AGENTSEEK_MODEL`、`OPENAI_API_BASE` 和 `OPENAI_API_KEY`,`AGENTSEEK_MODEL_PROVIDER` 国内模型一般选择 `openai` 或者 `anthropic`,`AGENTSEEK_MODEL` 填写你所使用的模型名称，`OPENAI_API_BASE` 根据选择的模型提供商填写对应的baseurl，`OPENAI_API_KEY`这里填写API key。
 - **Tavily 搜索 Key**：`deepagents/research` 模板需要网络搜索，在 [app.tavily.com](https://app.tavily.com/) 获取免费 Key。
 - **LangSmith Tracing**（强烈推荐）：在 [smith.langchain.com](https://smith.langchain.com/) 注册后，进入 Settings → API Keys 创建 Token 填入即可。个人用户每月 5000 次免费 Trace 额度。
 

--- a/content/pre01-agentseek-create.md
+++ b/content/pre01-agentseek-create.md
@@ -226,7 +226,9 @@ LANGSMITH_API_KEY=<your-langsmith-key>
 
 ### 配置要点
 
-- **模型供应商**：设置 `AGENTSEEK_MODEL_PROVIDER` 和 `AGENTSEEK_MODEL`，选择一个供应商填写对应 API Key 即可。国内用户推荐使用通义千问（DashScope）。使用其他模型时只需修改 `AGENTSEEK_MODEL_PROVIDER`、`AGENTSEEK_MODEL`、`OPENAI_API_BASE` 和 `OPENAI_API_KEY`,`AGENTSEEK_MODEL_PROVIDER` 国内模型一般选择 `openai` 或者 `anthropic`,`AGENTSEEK_MODEL` 填写你所使用的模型名称，`OPENAI_API_BASE` 根据选择的模型提供商填写对应的baseurl，`OPENAI_API_KEY`这里填写API key。
+- **模型供应商**：设置 `AGENTSEEK_MODEL_PROVIDER` 和 `AGENTSEEK_MODEL`，选择一个供应商填写对应 API Key 即可。国内用户推荐使用通义千问（DashScope）。
+  - 使用其他模型时只需修改 `AGENTSEEK_MODEL_PROVIDER`、`AGENTSEEK_MODEL`、`OPENAI_API_BASE` 和 `OPENAI_API_KEY`。
+  - `AGENTSEEK_MODEL_PROVIDER` 国内模型一般选择 `openai` 或者 `anthropic`，`AGENTSEEK_MODEL` 填写你所使用的模型名称，`OPENAI_API_BASE` 根据选择的模型提供商填写对应的 Base URL，`OPENAI_API_KEY` 这里填写 API Key。
 - **Tavily 搜索 Key**：`deepagents/research` 模板需要网络搜索，在 [app.tavily.com](https://app.tavily.com/) 获取免费 Key。
 - **LangSmith Tracing**（强烈推荐）：在 [smith.langchain.com](https://smith.langchain.com/) 注册后，进入 Settings → API Keys 创建 Token 填入即可。个人用户每月 5000 次免费 Trace 额度。
 


### PR DESCRIPTION
我在使用过程中配置了minimax的模型，我感觉对于一些小白来说，可能把需要配置的几个关键变量说清楚可能会好一点，这样可能可以快速上手使用这个框架。
原文档仅推荐通义千问一种国内模型，对于选择其他模型（如MiniMax、DeepSeek等）的用户，缺少 AGENTSEEK_MODEL_PROVIDER、AGENTSEEK_MODEL、OPENAI_API_BASE、OPENAI_API_KEY 的填写指引。 我补充了使用其他模型时的配置方式说明。
这次修改只在(content/pre01-agentseek-create.md) 第 229 行的「配置要点」中追加一段使用其他模型时的配置说明。