### PR TITLE
docs(README): add FilesystemBackend virtual_mode version requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 > [!WARNING]
 > 本课程讲授的 Deep Agents 版本为 **≥ 0.5**。
-> 部分进阶功能有更高最低版本要求，章节正文会单独标注；例如 `FilesystemPermission` 基础权限需要 `deepagents>=0.5.2`，`FilesystemBackend` 的 `virtual_mode` 参数需要 `deepagents>=0.6.0`，`interrupt` 权限模式需要 `deepagents>=0.6.8`。
+> 部分进阶功能有更高最低版本要求，章节正文会单独标注；例如 `FilesystemPermission` 基础权限需要 `deepagents>=0.5.2`，`FilesystemBackend` 的 `virtual_mode` 参数需要 `deepagents>=0.5.0`，`interrupt` 权限模式需要 `deepagents>=0.6.8`。
 > 官方文档：[Deep Agents Overview](https://docs.langchain.com/oss/python/deepagents/overview)
 
 > [!NOTE]

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 > [!WARNING]
 > 本课程讲授的 Deep Agents 版本为 **≥ 0.5**。
-> 部分进阶功能有更高最低版本要求，章节正文会单独标注；例如 `FilesystemPermission` 基础权限需要 `deepagents>=0.5.2`，`interrupt` 权限模式需要 `deepagents>=0.6.8`。
+> 部分进阶功能有更高最低版本要求，章节正文会单独标注；例如 `FilesystemPermission` 基础权限需要 `deepagents>=0.5.2`，`FilesystemBackend` 的 `virtual_mode` 参数需要 `deepagents>=0.6.0`，`interrupt` 权限模式需要 `deepagents>=0.6.8`。
 > 官方文档：[Deep Agents Overview](https://docs.langchain.com/oss/python/deepagents/overview)
 
 > [!NOTE]


### PR DESCRIPTION
## 改动说明

README 版本警告处补充 `FilesystemBackend` 的 `virtual_mode` 参数最低版本要求。

## 动机

ch03 明确写了 `virtual_mode` 从 0.6.0 起变为必填，但 README 的版本警告示例只列了 `FilesystemPermission (>=0.5.2)` 和 `interrupt (>=0.6.8)`，漏掉了 `virtual_mode`。补充这条信息帮读者在开始学习前就了解哪些章节需要更高的最低版本。

## 改动

```
- 例如 FilesystemPermission 基础权限需要 >=0.5.2，interrupt 权限模式需要 >=0.6.8
+ 例如 FilesystemPermission 基础权限需要 >=0.5.2，FilesystemBackend 的 virtual_mode 参数需要 >=0.6.0，interrupt 权限模式需要 >=0.6.8
```