### PR TITLE
docs(CONTRIBUTING,README): document H1 heading stripping during content prep

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,6 +95,9 @@ docs: 改善第 X 章 <简要说明>
 它读取 `scripts/chapters.json` 中的元数据，为 `content/` 下的 Markdown 注入 frontmatter，  
 生成到 `src/content/chapters/`（已加入 `.gitignore`，无需提交）。
 
+> 注意：`content/` 下 `.md` 文件的首行 H1 标题（`# 第X章...`）在生成时会被自动移除，
+> 页面标题统一取自 `scripts/chapters.json` 中的 `title` 字段。
+
 ### 文件不要提交
 
 以下目录已在 `.gitignore` 中，请勿手动提交：

--- a/README.md
+++ b/README.md
@@ -199,6 +199,9 @@ deepagents-in-action/
 `content/` 目录中的 Markdown 文件是**源文件**，不含 frontmatter。  
 `scripts/prep-content.mjs` 在 `dev` / `build` 前自动运行，从 `scripts/chapters.json` 读取元数据，生成带 frontmatter 的文件到 `src/content/chapters/`。
 
+> 注意：`content/` 下 `.md` 文件的首行 H1 标题在生成时会被自动移除，
+> 页面标题统一取自 `scripts/chapters.json`。
+
 **添加或修改章节内容，只需编辑 `content/` 目录下对应的 `.md` 文件。**  
 **修改标题、发布状态、视频链接等元数据，编辑 `scripts/chapters.json`。**
 


### PR DESCRIPTION
## 改动说明

在 CONTRIBUTING.md 和 README.md 中分别补充说明：`prep-content.mjs` 会自动移除 `content/*.md` 的首行 H1 标题，页面标题统一取自 `scripts/chapters.json`。

## 动机

`scripts/prep-content.mjs` 第 26 行会在构建时移除章节文件的首行 H1，但项目文档未说明这个行为。贡献者可能困惑为什么自己写的标题在网站上不出现。

## 改动

CONTRIBUTING.md（内容预处理段落）+ README.md（内容流水线段落）各加 2 行 blockquote。

Closes #56