### PR TITLE
docs: 修正第 3 章 grep 与 read_file 描述

### DIFF
--- a/content/ch03-virtual-filesystem.md
+++ b/content/ch03-virtual-filesystem.md
@@ -28,7 +28,7 @@ Deep Agents 的虚拟文件系统提供了 6 个核心工具：
 | `write_file` | 创建新文件 | 写一份新的备忘录 |
 | `edit_file` | 对已有文件做精确字符串替换 | 用红笔修改文档 |
 | `glob` | 按模式匹配查找文件（如 `**/*.py`） | 在文件柜中按标签找 |
-| `grep` | 搜索文件内容，支持正则、上下文、计数 | 全文检索 |
+| `grep` | 搜索文件内容，按字面量匹配；支持内容输出和计数 | 全文检索 |
 
 ![虚拟文件系统六大工具：ls、read_file、write_file、edit_file、glob、grep](../public/imgs/07-infographic-six-tools.png)
 
@@ -41,7 +41,7 @@ Deep Agents 的虚拟文件系统提供了 6 个核心工具：
 对于大文件，`read_file` 支持按偏移量和行数读取，避免一次性把整个文件塞进上下文：
 
 ```python
-# 读取整个文件（默认前 2000 行）
+# 默认最多读取前 100 行
 read_file("/workspace/report.md")
 
 # 从第 100 行开始，读取 50 行
@@ -73,8 +73,8 @@ read_file("/workspace/report.md", offset=100, limit=50)
 # 找到所有包含 "TODO" 的 Python 文件
 grep("TODO", glob="**/*.py", output_mode="files_with_matches")
 
-# 查看匹配内容及前后 3 行上下文
-grep("def create_agent", output_mode="content", context=3)
+# 查看匹配内容
+grep("def create_agent", output_mode="content")
 ```
 
 ## 上下文自动管理：不只是存文件


### PR DESCRIPTION
本 PR 修正第 3 章「虚拟文件系统」中几处与当前 Deep Agents 工具定义不一致的描述。

修改内容：

1. 将 `grep` 的“支持正则”修正为“按字面量匹配”

   * 当前 `GrepSchema.pattern` 的描述为 `literal string, not regex`
   * 因此文档中不应写作“支持正则”

2. 将 `read_file` 示例中的“默认前 2000 行”修正为“默认最多读取前 100 行”

   * 本章节展示的是 Agent 工具层的 `read_file`
   * 当前工具层默认读取上限为 100 行
   * `BackendProtocol.read()` 的默认 `limit=2000` 属于后端接口层，不应混同为 `read_file` 工具默认行为

3. 移除 `grep(..., context=3)` 示例参数

   * 当前 `GrepSchema` 字段包括 `pattern`、`path`、`glob`、`output_mode`
   * 未提供 `context` 入参
   * `output_mode="content"` 可以返回匹配内容，但上下文行数不是通过 `context=3` 控制

验证：

* 已本地检查 `GrepSchema` 字段定义
* 已确认 `GrepSchema.pattern` 描述为字面量匹配而非正则
* 已确认 `read_file` 工具层默认读取上限为 100 行