### PR TITLE
fix: remove redundant InMemorySaver checkpointer in ch06 supervisor.py

### DIFF
--- a/content/ch06-async-subagents.md
+++ b/content/ch06-async-subagents.md
@@ -295,7 +295,6 @@ graph = builder.compile()
 import os
 
 from deepagents import AsyncSubAgent, create_deep_agent
-from langgraph.checkpoint.memory import InMemorySaver
 
 
 graph = create_deep_agent(
@@ -318,8 +317,7 @@ graph = create_deep_agent(
             ),
             graph_id="researcher",
         )
-    ],
-    checkpointer=InMemorySaver(),
+    ]
 )
 ```
 

--- a/content/ch06-async-subagents.md
+++ b/content/ch06-async-subagents.md
@@ -337,6 +337,21 @@ model = ChatOpenAI(
 
 然后把上面 `create_deep_agent()` 里的 `model=os.environ.get("MODEL_NAME", "openai:gpt-4.1-mini")` 替换成 `model=model` 即可。
 
+如果你想直接以 `python graphs/supervisor.py` 运行（例如做快速本地调试），需要手动为 `create_deep_agent()` 传入 `checkpointer=InMemorySaver()`，否则多轮对话的状态无法持久化。
+
+注意该参数**不能**在 `langgraph dev` 下使用，平台已内置持久化，传入会直接报 `ValueError`。
+
+```python
+from langgraph.checkpoint.memory import InMemorySaver
+
+graph = create_deep_agent(
+    model=...,
+    system_prompt=...,
+    subagents=[...],
+    checkpointer=InMemorySaver(),
+)
+```
+
 ### 第 6 步：启动本地 Agent Server
 
 Worker 槽位要至少容纳 1 个 Supervisor + 1 个 Researcher 的运行。这里的演示建议直接开到 `4`：


### PR DESCRIPTION
## 问题

第 6 章 - 第 5 步：创建 Supervisor"的示例代码中，`create_deep_agent()` 传入了 `checkpointer=InMemorySaver()`，在执行 `langgraph dev` 时会直接报错，服务无法启动：
```
`ValueError: Heads up! Your graph 'graph' from './graphs/supervisor.py' includes a custom checkpointer (type <class 'langgraph.checkpoint.memory.InMemorySaver'>). With LangGraph API, persistence is handled automatically by the platform, so providing a custom checkpointer here isn't necessary and will be ignored when deployed.

To simplify your setup and use the built-in persistence, please remove the custom checkpointer from your graph definition.
```

复现环境：`langgraph-cli 0.4.30` / `langgraph-api 0.10.1`。

## 原因
两种运行模式对 checkpointer 的处理方式截然不同：

| 运行方式 | checkpointer 要求 |
| --- | --- |
| langgraph dev | 平台已内置持久化，不能传入，传入报 ValueError |
| python graphs/supervisor.py | 必须手动传入，否则多轮对话状态无法持久化 |

## 修改内容

- 主代码块移除 checkpointer=InMemorySaver() 及对应 import，适配 langgraph dev 场景
- 在其后补充说明：直接以脚本运行时需手动传入 checkpointer=InMemorySaver()，并附代码示例说明加在何处
- 两种场景均已本地验证
