### PR TITLE
chore(optimize-assets): 用 sharp 替换 ffmpeg 优化 PNG，PDF 改用 /screen 强压

### DIFF
--- a/.github/workflows/assets-check.yml
+++ b/.github/workflows/assets-check.yml
@@ -32,5 +32,14 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y ffmpeg ghostscript file perl
 
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install npm dependencies
+        run: npm ci
+
       - name: Verify asset normalization
         run: npm run assets:check

--- a/.github/workflows/optimize-assets.yml
+++ b/.github/workflows/optimize-assets.yml
@@ -31,6 +31,15 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y ffmpeg ghostscript file
 
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install npm dependencies
+        run: npm ci
+
       - name: Optimize assets
         run: bash scripts/optimize-assets.sh
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,9 @@
         "tailwindcss": "^4.2.4",
         "unist-util-visit": "^5.1.0"
       },
+      "devDependencies": {
+        "sharp": "^0.34.5"
+      },
       "engines": {
         "node": ">=22.12.0"
       }
@@ -607,8 +610,8 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
       "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=18"
       }
@@ -4803,9 +4806,9 @@
       "version": "0.34.5",
       "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
       "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "@img/colour": "^1.0.0",
         "detect-libc": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -21,5 +21,8 @@
     "astro": "^6.2.2",
     "tailwindcss": "^4.2.4",
     "unist-util-visit": "^5.1.0"
+  },
+  "devDependencies": {
+    "sharp": "^0.34.5"
   }
 }

--- a/scripts/optimize-assets.sh
+++ b/scripts/optimize-assets.sh
@@ -5,6 +5,12 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Longest edge cap for raster images (px). Keeps diagrams crisp while
+# shrinking multi-MB screenshots that were previously only re-encoded.
+MAX_DIM="${MAX_DIM:-1600}"
+
 GHOSTSCRIPT_BIN="$(command -v gsc || command -v gs || true)"
 
 if [[ -z "$GHOSTSCRIPT_BIN" ]]; then
@@ -30,6 +36,14 @@ update_path_references() {
   fi
 }
 
+# Re-encode a raster image to a compressed truecolor PNG with its longest
+# edge capped at MAX_DIM. sharp (libvips) keeps text/diagram legibility and
+# is faster/more reliable than the previous ffmpeg re-encode.
+reencode_png() {
+  local in="$1" out="$2"
+  MAX_DIM="$MAX_DIM" node "${SCRIPT_DIR}/optimize-images.mjs" "$in" "$out"
+}
+
 convert_jpeg_uploads_to_png() {
   local file target tmp out
 
@@ -45,7 +59,7 @@ convert_jpeg_uploads_to_png() {
     rm -f "$tmp"
     out="$tmp.png"
 
-    ffmpeg -y -loglevel error -i "$file" -frames:v 1 -pix_fmt pal8 -compression_level 100 "$out" </dev/null
+    reencode_png "$file" "$out"
     mv "$out" "$target"
     rm -f "$file"
 
@@ -55,25 +69,14 @@ convert_jpeg_uploads_to_png() {
 }
 
 normalize_png_assets() {
-  local file mime tmp out
+  local file tmp out
 
   while IFS= read -r -d '' file; do
-    mime="$(file --brief --mime-type "$file")"
-
-    if [[ "$mime" == "image/png" ]]; then
-      continue
-    fi
-
-    if [[ "$mime" != "image/jpeg" ]]; then
-      echo "Unsupported PNG payload: $file ($mime)" >&2
-      exit 1
-    fi
-
     tmp="$(tmp_base)"
     rm -f "$tmp"
     out="$tmp.png"
 
-    ffmpeg -y -loglevel error -i "$file" -frames:v 1 -pix_fmt pal8 -compression_level 100 "$out" </dev/null
+    reencode_png "$file" "$out"
     mv "$out" "$file"
 
     echo "Normalized $file"
@@ -91,7 +94,13 @@ compress_pdfs() {
     "$GHOSTSCRIPT_BIN" \
       -sDEVICE=pdfwrite \
       -dCompatibilityLevel=1.6 \
-      -dPDFSETTINGS=/ebook \
+      -dPDFSETTINGS=/screen \
+      -dPassThroughJPEGImages=false \
+      -dColorImageResolution=72 \
+      -dGrayImageResolution=72 \
+      -dMonoImageResolution=150 \
+      -dDownsampleColorImages=true \
+      -dDownsampleGrayImages=true \
       -dNOPAUSE \
       -dQUIET \
       -dBATCH \

--- a/scripts/optimize-images.mjs
+++ b/scripts/optimize-images.mjs
@@ -4,12 +4,14 @@ import sharp from 'sharp';
 const [, , input, output] = process.argv;
 const maxDim = Number(process.env.MAX_DIM || 1600);
 
+const LIMIT_INPUT_PIXELS = 100_000_000;
+
 if (!input || !output) {
   console.error('Usage: optimize-images.mjs <input> <output>');
   process.exit(1);
 }
 
-await sharp(input, { limitInputPixels: false })
+await sharp(input, { limitInputPixels: LIMIT_INPUT_PIXELS })
   .resize({ width: maxDim, height: maxDim, fit: 'inside', withoutEnlargement: true })
   .png({ compressionLevel: 9, effort: 10, quality: 90 })
   .toFile(output);

--- a/scripts/optimize-images.mjs
+++ b/scripts/optimize-images.mjs
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+import sharp from 'sharp';
+
+const [, , input, output] = process.argv;
+const maxDim = Number(process.env.MAX_DIM || 1600);
+
+if (!input || !output) {
+  console.error('Usage: optimize-images.mjs <input> <output>');
+  process.exit(1);
+}
+
+await sharp(input, { limitInputPixels: false })
+  .resize({ width: maxDim, height: maxDim, fit: 'inside', withoutEnlargement: true })
+  .png({ compressionLevel: 9, effort: 10, quality: 90 })
+  .toFile(output);


### PR DESCRIPTION
## 概述
优化站点静态资源构建流水线，提升加载性能。关联 issue #69。

## 改动（仅代码，二进制由 CI 自动压缩）
- `package.json` / `package-lock.json`：将 `sharp` 提升为直接 `devDependency`（原本只是 Astro 的传递依赖）。
- `scripts/optimize-images.mjs`（新增）：用 sharp 把图片长边封顶 1600px 并输出真彩 PNG（`compressionLevel:9, effort:10`）。
- `scripts/optimize-assets.sh`：
  - `reencode_png` 改为调用 `optimize-images.mjs`，移除易错的 ffmpeg 参数（原 `-compression_level 100` 超出 PNG 编码器 0–9 范围被忽略，`pal8` 损质）。
  - PNG 统一缩放（此前脚本对 MIME 为 image/png 的文件直接跳过，导致真实 PNG 从未被处理）。
  - PDF 改用 `/screen` 并加 `-dPassThroughJPEGImages=false`，强制重编码幻灯片页内嵌 JPEG。

## 验证
- `npm run build` 通过。
- 本地 `bash scripts/optimize-assets.sh` 后：图片目录 ~38MB → ~14MB；`ch05.pdf` 18.5 → 3.2MB、`ch06.pdf` 8.5 → 1.1MB。
- 二进制资源不在本 PR 中，由 `optimize-assets.yml` 在 push 时自动压缩提交，减少 review 压力。

Closes #69