### PR TITLE
feat: 新增暗色模式支持，完善全站主题适配

### DIFF
--- a/src/components/BackToTop.astro
+++ b/src/components/BackToTop.astro
@@ -61,6 +61,11 @@
       transform: none;
     }
   }
+
+  /* 暗色模式适配 */
+  :global([data-theme="dark"]) .back-to-top {
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
+  }
 </style>
 
 <script>

--- a/src/components/ChapterCard.astro
+++ b/src/components/ChapterCard.astro
@@ -24,7 +24,7 @@ const chapterLabel = isExtra ? (preMatch ? preMatch[1] : 'EX') : String(chapter)
 ---
 
 {published ? (
-  <div class="relative p-6 rounded-lg border border-gold-pale/80 bg-white hover:border-gold-light hover:shadow-md transition-all group overflow-hidden">
+  <div class="relative p-6 rounded-lg border border-gold-pale/80 bg-paper-warm hover:border-gold-light hover:shadow-md transition-all group overflow-hidden">
     <div class={`chapter-num ${isExtra ? 'chapter-num--extra' : ''}`}>{chapterLabel}</div>
     <a href={`${base}/chapters/${id}/`} class="relative block">
       <h3 class="text-lg font-bold font-sans leading-snug mb-2 group-hover:text-gold transition-colors">
@@ -79,3 +79,32 @@ const chapterLabel = isExtra ? (preMatch ? preMatch[1] : 'EX') : String(chapter)
     <p class="text-sm text-ink-muted/30">即将发布</p>
   </div>
 )}
+
+<style>
+  /* 暗色模式：B站按钮 */
+  :global([data-theme="dark"]) a[href*="bilibili"]:not([href*="xhs"]) {
+    background: rgba(56, 189, 248, 0.15);
+    color: #5ba3e8;
+  }
+
+  :global([data-theme="dark"]) a[href*="bilibili"]:not([href*="xhs"]):hover {
+    background: rgba(56, 189, 248, 0.25);
+  }
+
+  /* 暗色模式：小红书按钮 */
+  :global([data-theme="dark"]) a[href*="xiaohongshu"],
+  :global([data-theme="dark"]) a[href*="xhs"] {
+    background: rgba(239, 68, 68, 0.15);
+    color: #f87171;
+  }
+
+  :global([data-theme="dark"]) a[href*="xiaohongshu"]:hover,
+  :global([data-theme="dark"]) a[href*="xhs"]:hover {
+    background: rgba(239, 68, 68, 0.25);
+  }
+
+  /* 暗色模式：卡片hover阴影 */
+  :global([data-theme="dark"]) .group:hover {
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
+  }
+</style>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,4 +1,6 @@
 ---
+import ThemeToggle from './ThemeToggle.astro';
+
 const base = import.meta.env.BASE_URL;
 ---
 
@@ -19,9 +21,12 @@ const base = import.meta.env.BASE_URL;
       </svg>
       <span class="font-sans font-medium text-sm text-ink-muted tracking-wide group-hover:text-gold transition-colors">Deep Agents 实战</span>
     </a>
-    <a href="https://github.com/datawhalechina/deepagents-in-action" target="_blank" rel="noopener" class="flex items-center gap-1.5 text-xs text-ink-muted/50 font-mono tracking-wider hover:text-ink-muted transition-colors group" aria-label="GitHub">
-      <svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"/></svg>
-      <span class="hidden sm:inline">开源课程</span>
-    </a>
+    <div class="flex items-center gap-3">
+      <ThemeToggle />
+      <a href="https://github.com/datawhalechina/deepagents-in-action" target="_blank" rel="noopener" class="flex items-center gap-1.5 text-xs text-ink-muted/50 font-mono tracking-wider hover:text-ink-muted transition-colors group" aria-label="GitHub">
+        <svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"/></svg>
+        <span class="hidden sm:inline">开源课程</span>
+      </a>
+    </div>
   </nav>
 </header>

--- a/src/components/PdfDownload.astro
+++ b/src/components/PdfDownload.astro
@@ -16,7 +16,7 @@ const base = import.meta.env.BASE_URL;
     {slides.map((slide) => (
       <a
         href={`${base}/pdfs/${slide.id}.pdf`}
-        class="pdf-link inline-flex items-center gap-2 px-4 py-2 bg-white border border-gold-pale/80 rounded-lg text-sm text-ink-muted hover:border-gold-light hover:text-gold hover:shadow-sm transition-all"
+        class="pdf-link inline-flex items-center gap-2 px-4 py-2 bg-paper-warm border border-gold-pale/80 rounded-lg text-sm text-ink-muted hover:border-gold-light hover:text-gold hover:shadow-sm transition-all"
         data-pdf-check
       >
         <svg class="w-4 h-4 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/src/components/Prose.astro
+++ b/src/components/Prose.astro
@@ -14,7 +14,7 @@
   prose-img:rounded-xl prose-img:shadow-md prose-img:my-8
   prose-a:text-accent prose-a:no-underline prose-a:font-medium hover:prose-a:underline
   max-w-none
-  [&_pre]:rounded-xl [&_pre]:shadow-md [&_pre]:bg-[#1a1a2e] [&_pre]:border [&_pre]:border-ink-light/20
+  [&_pre]:rounded-xl [&_pre]:shadow-md [&_pre]:bg-[#1a1a2e] [&_pre]:border [&_pre]:border-gold-pale/60
   [&_pre_code]:bg-transparent [&_pre_code]:p-0 [&_pre_code]:text-sm [&_pre_code]:text-gray-200 [&_pre_code]:leading-relaxed [&_pre_code]:before:content-none [&_pre_code]:after:content-none
   [&_code]:before:content-none [&_code]:after:content-none [&_code]:bg-gold-pale/50 [&_code]:text-ink [&_code]:px-1.5 [&_code]:py-0.5 [&_code]:rounded [&_code]:text-sm [&_code]:font-mono
   [&_li]:leading-relaxed [&_li]:mb-1
@@ -22,3 +22,118 @@
 ">
   <slot />
 </div>
+
+<style>
+  /* 浅色模式：引用块背景 */
+  .prose blockquote {
+    background: rgba(245, 234, 214, 0.4);
+  }
+
+  /* 暗色模式 Prose 适配 */
+  :global([data-theme="dark"]) .prose {
+    --tw-prose-body: var(--color-ink);
+    --tw-prose-headings: var(--color-ink);
+    --tw-prose-links: var(--color-accent);
+    --tw-prose-bold: var(--color-ink);
+    --tw-prose-counters: var(--color-ink-muted);
+    --tw-prose-bullets: var(--color-ink-muted);
+    --tw-prose-quotes: var(--color-ink-muted);
+    --tw-prose-th-borders: var(--color-gold-pale);
+    --tw-prose-td-borders: var(--color-gold-pale);
+  }
+
+  /* 暗色模式：强制覆盖所有文字颜色 */
+  :global([data-theme="dark"]) .prose p,
+  :global([data-theme="dark"]) .prose li,
+  :global([data-theme="dark"]) .prose ol,
+  :global([data-theme="dark"]) .prose ul,
+  :global([data-theme="dark"]) .prose dd,
+  :global([data-theme="dark"]) .prose dt,
+  :global([data-theme="dark"]) .prose figcaption {
+    color: var(--color-ink);
+  }
+
+  /* 暗色模式：标题颜色 */
+  :global([data-theme="dark"]) .prose h1,
+  :global([data-theme="dark"]) .prose h2,
+  :global([data-theme="dark"]) .prose h3,
+  :global([data-theme="dark"]) .prose h4,
+  :global([data-theme="dark"]) .prose h5,
+  :global([data-theme="dark"]) .prose h6 {
+    color: var(--color-ink);
+  }
+
+  /* 暗色模式：加粗文字 */
+  :global([data-theme="dark"]) .prose strong {
+    color: var(--color-ink);
+  }
+
+  /* 暗色模式：引用块内的文字 */
+  :global([data-theme="dark"]) .prose blockquote p {
+    color: var(--color-ink-muted);
+  }
+
+  /* 暗色模式：代码块样式 */
+  :global([data-theme="dark"]) .prose pre {
+    background: #1a1a2a;
+    border-color: var(--color-gold-pale);
+  }
+
+  /* 暗色模式：行内代码 */
+  :global([data-theme="dark"]) .prose code:not(pre code) {
+    background: rgba(58, 53, 40, 0.8) !important;
+    color: #e8c47a !important;
+    border-radius: 4px !important;
+    padding: 0.125rem 0.375rem !important;
+    font-family: "JetBrains Mono", monospace !important;
+    font-size: 0.875rem !important;
+  }
+
+  /* 暗色模式：行内代码 - 更强的选择器 */
+  :global([data-theme="dark"]) .prose p code,
+  :global([data-theme="dark"]) .prose li code,
+  :global([data-theme="dark"]) .prose td code,
+  :global([data-theme="dark"]) .prose th code,
+  :global([data-theme="dark"]) .prose strong code,
+  :global([data-theme="dark"]) .prose em code,
+  :global([data-theme="dark"]) .prose a code {
+    background: rgba(58, 53, 40, 0.8) !important;
+    color: #e8c47a !important;
+    border-radius: 4px !important;
+    padding: 0.125rem 0.375rem !important;
+  }
+
+  /* 暗色模式：表格 */
+  :global([data-theme="dark"]) .prose table {
+    border-color: var(--color-gold-pale);
+  }
+
+  :global([data-theme="dark"]) .prose th {
+    border-color: var(--color-gold-pale);
+    color: var(--color-ink);
+  }
+
+  :global([data-theme="dark"]) .prose td {
+    border-color: var(--color-gold-pale);
+    color: var(--color-ink);
+  }
+
+  /* 暗色模式：链接 */
+  :global([data-theme="dark"]) .prose a {
+    color: var(--color-accent);
+  }
+
+  :global([data-theme="dark"]) .prose a:hover {
+    color: var(--color-accent);
+  }
+
+  /* 暗色模式：列表标记 */
+  :global([data-theme="dark"]) .prose li::marker {
+    color: var(--color-ink-muted);
+  }
+
+  /* 暗色模式：分隔线 */
+  :global([data-theme="dark"]) .prose hr {
+    border-color: var(--color-gold-pale);
+  }
+</style>

--- a/src/components/SectionHeading.astro
+++ b/src/components/SectionHeading.astro
@@ -132,4 +132,17 @@ const meta = sectionMeta[title] || { num: '?', subtitle: '', accent: '#1a1a2e', 
       font-size: 1.125rem;
     }
   }
+
+  /* ========== 暗色模式适配 ========== */
+
+  /* 暗色模式下调整背景亮度 */
+  :global([data-theme="dark"]) .section-banner {
+    background: linear-gradient(135deg, rgba(255,255,255,0.02) 0%, rgba(255,255,255,0.04) 100%);
+  }
+
+  /* 暗色模式下罗马数字改用暗金 */
+  :global([data-theme="dark"]) .section-banner__num {
+    color: var(--color-gold);
+    opacity: 0.35;
+  }
 </style>

--- a/src/components/SocialLinks.astro
+++ b/src/components/SocialLinks.astro
@@ -60,3 +60,31 @@ const items = slides.some(s => s.bilibili || s.xhs)
     ))}
   </div>
 </section>
+
+<style>
+  /* 暗色模式：B站按钮 */
+  :global([data-theme="dark"]) a[href*="bilibili"] {
+    background: rgba(56, 189, 248, 0.15);
+    border-color: rgba(56, 189, 248, 0.25);
+    color: #5ba3e8;
+  }
+
+  :global([data-theme="dark"]) a[href*="bilibili"]:hover {
+    background: rgba(56, 189, 248, 0.25);
+    border-color: rgba(56, 189, 248, 0.35);
+  }
+
+  /* 暗色模式：小红书按钮 */
+  :global([data-theme="dark"]) a[href*="xiaohongshu"],
+  :global([data-theme="dark"]) a[href*="xhs"] {
+    background: rgba(239, 68, 68, 0.15);
+    border-color: rgba(239, 68, 68, 0.25);
+    color: #f87171;
+  }
+
+  :global([data-theme="dark"]) a[href*="xiaohongshu"]:hover,
+  :global([data-theme="dark"]) a[href*="xhs"]:hover {
+    background: rgba(239, 68, 68, 0.25);
+    border-color: rgba(239, 68, 68, 0.35);
+  }
+</style>

--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -1,0 +1,172 @@
+---
+/**
+ * 主题切换按钮组件
+ * 支持：
+ * 1. 系统偏好 (prefers-color-scheme)
+ * 2. 手动切换存储 (localStorage)
+ * 3. 优先响应手动选择
+ */
+---
+
+<button
+  type="button"
+  class="theme-toggle"
+  aria-label="切换主题"
+  data-theme-toggle
+>
+  <!-- 太阳图标 (浅色模式) -->
+  <svg class="theme-toggle__icon theme-toggle__icon--sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <circle cx="12" cy="12" r="4"/>
+    <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41"/>
+  </svg>
+  <!-- 月亮图标 (暗色模式) -->
+  <svg class="theme-toggle__icon theme-toggle__icon--moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+  </svg>
+</button>
+
+<style>
+  .theme-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2rem;
+    height: 2rem;
+    border-radius: 6px;
+    border: 1px solid var(--color-gold-pale);
+    background: transparent;
+    color: var(--color-ink-muted);
+    cursor: pointer;
+    transition: border-color 0.2s, color 0.2s, background 0.2s;
+  }
+
+  .theme-toggle:hover {
+    border-color: var(--color-gold);
+    color: var(--color-gold);
+  }
+
+  .theme-toggle:focus-visible {
+    outline: none;
+    border-color: var(--color-gold);
+    box-shadow: 0 0 0 2px var(--color-gold-pale);
+  }
+
+  .theme-toggle__icon {
+    width: 1.125rem;
+    height: 1.125rem;
+    transition: opacity 0.2s, transform 0.2s;
+  }
+
+  /* 浅色模式：显示月亮图标（点击切换到暗色） */
+  .theme-toggle__icon--sun {
+    opacity: 1;
+    transform: rotate(0deg);
+  }
+
+  .theme-toggle__icon--moon {
+    opacity: 0;
+    transform: rotate(-90deg);
+    position: absolute;
+  }
+
+  /* 暗色模式：显示太阳图标（点击切换到浅色） */
+  :global([data-theme="dark"]) .theme-toggle__icon--sun {
+    opacity: 0;
+    transform: rotate(90deg);
+    position: absolute;
+  }
+
+  :global([data-theme="dark"]) .theme-toggle__icon--moon {
+    opacity: 1;
+    transform: rotate(0deg);
+  }
+
+  /* 过渡动画 */
+  @media (prefers-reduced-motion: no-preference) {
+    .theme-toggle__icon {
+      transition: opacity 0.25s ease, transform 0.25s ease;
+    }
+  }
+</style>
+
+<script>
+  const STORAGE_KEY = 'theme:preference';
+  const THEME_LIGHT = 'light';
+  const THEME_DARK = 'dark';
+
+  function getSystemTheme(): string {
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? THEME_DARK : THEME_LIGHT;
+  }
+
+  function getStoredTheme(): string | null {
+    try {
+      return localStorage.getItem(STORAGE_KEY);
+    } catch {
+      return null;
+    }
+  }
+
+  function applyTheme(theme: string) {
+    document.documentElement.setAttribute('data-theme', theme);
+  }
+
+  function toggleTheme() {
+    const current = document.documentElement.getAttribute('data-theme') || THEME_LIGHT;
+    const next = current === THEME_LIGHT ? THEME_DARK : THEME_LIGHT;
+    applyTheme(next);
+    try {
+      localStorage.setItem(STORAGE_KEY, next);
+    } catch {}
+  }
+
+  function initTheme() {
+    // 优先级：localStorage > 系统偏好 > 默认浅色
+    const stored = getStoredTheme();
+    if (stored) {
+      applyTheme(stored);
+    } else {
+      applyTheme(getSystemTheme());
+    }
+  }
+
+  // 立即初始化（避免闪烁）
+  initTheme();
+
+  // 监听系统偏好变化（仅当用户未手动设置时）
+  window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (e) => {
+    if (!getStoredTheme()) {
+      applyTheme(e.matches ? THEME_DARK : THEME_LIGHT);
+    }
+  });
+
+  // 绑定按钮点击事件
+  document.querySelectorAll('[data-theme-toggle]').forEach((btn) => {
+    btn.addEventListener('click', toggleTheme);
+  });
+</script>
+
+<!-- Astro 页面切换后重新初始化 -->
+<script is:inline>
+  // 在页面加载前立即应用主题，避免闪烁
+  (function() {
+    const STORAGE_KEY = 'theme:preference';
+    const THEME_DARK = 'dark';
+    const THEME_LIGHT = 'light';
+
+    function getStoredTheme() {
+      try {
+        return localStorage.getItem(STORAGE_KEY);
+      } catch {
+        return null;
+      }
+    }
+
+    function getSystemTheme() {
+      return window.matchMedia('(prefers-color-scheme: dark)').matches ? THEME_DARK : THEME_LIGHT;
+    }
+
+    const stored = getStoredTheme();
+    const theme = stored || getSystemTheme();
+    document.documentElement.setAttribute('data-theme', theme);
+  })();
+</script>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -6,6 +6,7 @@
   --font-serif: "LXGW WenKai", "Noto Serif SC", "Source Han Serif SC", "Songti SC", Georgia, serif;
   --font-mono: "JetBrains Mono", "Fira Code", "Menlo", "Consolas", monospace;
 
+  /* 浅色模式（默认） */
   --color-ink: #1a1a2e;
   --color-ink-light: #2d2d44;
   --color-ink-muted: #4a4a5a;
@@ -22,6 +23,58 @@ html {
   scroll-behavior: smooth;
 }
 
+/* ========== 暗色模式 CSS 变量覆盖 ========== */
+[data-theme="dark"] {
+  --color-ink: #c9c5bf;
+  --color-ink-light: #b8b4a8;
+  --color-ink-muted: #8a8678;
+  --color-paper: #0f0f1a;
+  --color-paper-warm: #16162a;
+  --color-gold: #c9a227;
+  --color-gold-light: #daa520;
+  --color-gold-pale: #2a2518;
+  --color-accent: #5ba3e8;
+}
+
+/* 暗色模式：Tailwind 文字类强制覆盖 */
+[data-theme="dark"] .text-ink,
+[data-theme="dark"] [class*="text-ink"] {
+  color: var(--color-ink) !important;
+}
+
+[data-theme="dark"] .text-ink-light {
+  color: var(--color-ink-light) !important;
+}
+
+[data-theme="dark"] .text-ink-muted {
+  color: var(--color-ink-muted) !important;
+}
+
+[data-theme="dark"] .text-gold {
+  color: var(--color-gold) !important;
+}
+
+[data-theme="dark"] .text-accent {
+  color: var(--color-accent) !important;
+}
+
+/* 暗色模式：无 Tailwind 文字类的纯元素降级 */
+[data-theme="dark"] h1,
+[data-theme="dark"] h2,
+[data-theme="dark"] h3,
+[data-theme="dark"] h4,
+[data-theme="dark"] h5,
+[data-theme="dark"] h6,
+[data-theme="dark"] p,
+[data-theme="dark"] li,
+[data-theme="dark"] td,
+[data-theme="dark"] th,
+[data-theme="dark"] label,
+[data-theme="dark"] strong,
+[data-theme="dark"] em {
+  color: var(--color-ink);
+}
+
 @media (prefers-reduced-motion: reduce) {
   html {
     scroll-behavior: auto;
@@ -36,6 +89,19 @@ body {
 ::selection {
   background-color: var(--color-gold-pale);
   color: var(--color-ink);
+}
+
+/* 暗色模式：prose 引用块 */
+[data-theme="dark"] .prose blockquote {
+  background: rgba(255, 255, 255, 0.04) !important;
+  color: var(--color-ink-muted) !important;
+  border-left-color: var(--color-gold) !important;
+}
+
+/* 暗色模式：行内代码 */
+[data-theme="dark"] .prose code:not(pre code) {
+  background: rgba(255, 255, 255, 0.07) !important;
+  color: var(--color-ink) !important;
 }
 
 /* Dot grid background pattern */
@@ -241,4 +307,167 @@ body {
   border-radius: 4px;
   overflow-x: auto;
   text-overflow: ellipsis;
+}
+
+/* ========== 暗色模式特殊样式 ========== */
+
+/* 点状网格背景 - 暗色模式下调整颜色 */
+[data-theme="dark"] .bg-dot-grid {
+  background-image: radial-gradient(circle, #3a3a4a 0.8px, transparent 0.8px);
+}
+
+/* 章节号装饰 - 暗色模式下降低透明度 */
+[data-theme="dark"] .chapter-num {
+  opacity: 0.15;
+}
+
+[data-theme="dark"] .chapter-num--extra {
+  opacity: 0.12;
+}
+
+/* 技能卡片 - 暗色模式下背景调整 */
+[data-theme="dark"] .skills-promo__card {
+  background: var(--color-paper-warm);
+}
+
+[data-theme="dark"] .skills-promo__card:hover {
+  box-shadow: 0 2px 8px rgba(5, 150, 105, 0.15);
+}
+
+/* 技能卡片命令 - 暗色模式下背景调整 */
+[data-theme="dark"] .skills-promo__card-cmd {
+  background: rgba(5, 150, 105, 0.08);
+}
+
+/* 技能卡片操作按钮 - 暗色模式下 */
+[data-theme="dark"] .skills-promo__action:hover {
+  background: rgba(5, 150, 105, 0.15);
+}
+
+/* 边框颜色覆盖 */
+[data-theme="dark"] .border-gold-pale {
+  border-color: var(--color-gold-pale) !important;
+}
+
+[data-theme="dark"] .border-gold {
+  border-color: var(--color-gold) !important;
+}
+
+[data-theme="dark"] .border-gold\/40 {
+  border-color: rgba(212, 168, 83, 0.4) !important;
+}
+
+[data-theme="dark"] .border-gold\/30 {
+  border-color: rgba(212, 168, 83, 0.3) !important;
+}
+
+[data-theme="dark"] .border-gold\/20 {
+  border-color: rgba(212, 168, 83, 0.2) !important;
+}
+
+/* 背景颜色覆盖 */
+[data-theme="dark"] .bg-paper {
+  background-color: var(--color-paper) !important;
+}
+
+[data-theme="dark"] .bg-paper-warm {
+  background-color: var(--color-paper-warm) !important;
+}
+
+[data-theme="dark"] .bg-gold-pale {
+  background-color: var(--color-gold-pale) !important;
+}
+
+[data-theme="dark"] .bg-gold {
+  background-color: var(--color-gold) !important;
+}
+
+[data-theme="dark"] .bg-gold\/40 {
+  background-color: rgba(212, 168, 83, 0.4) !important;
+}
+
+[data-theme="dark"] .bg-gold\/30 {
+  background-color: rgba(212, 168, 83, 0.3) !important;
+}
+
+[data-theme="dark"] .bg-gold\/20 {
+  background-color: rgba(212, 168, 83, 0.2) !important;
+}
+
+[data-theme="dark"] .bg-gold-pale\/40 {
+  background-color: rgba(58, 53, 40, 0.4) !important;
+}
+
+[data-theme="dark"] .bg-gold-pale\/30 {
+  background-color: rgba(58, 53, 40, 0.3) !important;
+}
+
+[data-theme="dark"] .bg-gold-pale\/50 {
+  background-color: rgba(58, 53, 40, 0.5) !important;
+}
+
+[data-theme="dark"] .bg-gold-pale\/60 {
+  background-color: rgba(58, 53, 40, 0.6) !important;
+}
+
+/* 带 opacity 的文字颜色覆盖 - 暗色模式下提高亮度 */
+[data-theme="dark"] .text-ink-muted\/30 {
+  color: rgba(184, 180, 168, 0.7) !important;
+}
+
+[data-theme="dark"] .text-ink-muted\/35 {
+  color: rgba(184, 180, 168, 0.75) !important;
+}
+
+[data-theme="dark"] .text-ink-muted\/40 {
+  color: rgba(184, 180, 168, 0.8) !important;
+}
+
+[data-theme="dark"] .text-ink-muted\/50 {
+  color: rgba(184, 180, 168, 0.85) !important;
+}
+
+[data-theme="dark"] .text-ink-muted\/60 {
+  color: rgba(184, 180, 168, 0.9) !important;
+}
+
+[data-theme="dark"] .text-ink-muted\/65 {
+  color: rgba(184, 180, 168, 0.92) !important;
+}
+
+[data-theme="dark"] .text-ink-muted\/70 {
+  color: rgba(184, 180, 168, 0.95) !important;
+}
+
+[data-theme="dark"] .text-ink-muted\/75 {
+  color: rgba(184, 180, 168, 0.97) !important;
+}
+
+[data-theme="dark"] .text-ink-muted\/80 {
+  color: rgba(184, 180, 168, 1) !important;
+}
+
+[data-theme="dark"] .text-ink\/85 {
+  color: rgba(245, 242, 237, 1) !important;
+}
+
+[data-theme="dark"] .text-ink\/75 {
+  color: rgba(245, 242, 237, 0.95) !important;
+}
+
+[data-theme="dark"] .text-gold\/30 {
+  color: rgba(212, 168, 83, 0.5) !important;
+}
+
+[data-theme="dark"] .text-gold\/40 {
+  color: rgba(212, 168, 83, 0.6) !important;
+}
+
+[data-theme="dark"] .text-gold\/80 {
+  color: rgba(212, 168, 83, 1) !important;
+}
+
+/* 暗色模式：LangChain Community 图片反转 */
+[data-theme="dark"] img[src*="langchain-community"] {
+  filter: invert(0.85) hue-rotate(180deg);
 }


### PR DESCRIPTION
## 概述

为课程网站添加暗色模式，采用「深墨淡金」配色方案，保留原版书卷气息的同时提供舒适的夜间阅读体验。

## 变更文件

| 文件 | 变更 | 说明 |
|------|------|------|
| `src/components/ThemeToggle.astro` | +172 | **新增** 主题切换按钮组件 |
| `src/styles/global.css` | +229 | 暗色 CSS 变量 + Tailwind 类覆盖 |
| `src/components/Prose.astro` | +119/-1 | 暗色模式正文排版适配 |
| `src/components/Header.astro` | +13 | 集成主题切换按钮 |
| `src/components/ChapterCard.astro` | +31 | 暗色模式卡片样式 |
| `src/components/SectionHeading.astro` | +13 | 罗马数字暗金适配 |
| `src/components/SocialLinks.astro` | +30 | B站/小红书按钮暗色背景 |
| `src/components/BackToTop.astro` | +5 | 暗色阴影调整 |

**合计**：8 文件，+604 行，-8 行

## 功能特性

- **自动检测系统偏好**：根据 `prefers-color-scheme` 首次访问自动选择
- **手动切换记忆**：用户选择存储于 `localStorage`，下次访问保持
- **无闪烁加载**：`is:inline` 脚本在页面渲染前应用主题
- **平滑动画**：切换图标旋转过渡，`prefers-reduced-motion` 下禁用
- **完整适配**：正文排版（prose）、引用块、行内代码、代码块、表格、章节卡片、技能卡片等

## 暗色配色方案

| 元素 | 浅色 | 暗色 |
|------|------|------|
| 页面背景 | `#faf8f5` | `#0f0f1a` |
| 卡片背景 | `#f5f0e8` | `#16162a` |
| 主文字 | `#1a1a2e` | `#c9c5bf` |
| 强调金色 | `#b8860b` | `#c9a227` |
| 链接蓝色 | `#2b6cb0` | `#5ba3e8` |

## 截图

<img width="2560" height="1307" alt="Snipaste_2026-07-11_06-12-56" src="https://github.com/user-attachments/assets/3bb8644d-2673-407f-b911-1480c580128e" />

<img width="2560" height="1307" alt="Snipaste_2026-07-11_06-13-21" src="https://github.com/user-attachments/assets/5a4c5765-5d2d-4650-8e42-b77ebe1913f5" />
