### PR TITLE
完善 Middleware 中断与跨章节学习路径

### DIFF
--- a/content/ch03-virtual-filesystem.md
+++ b/content/ch03-virtual-filesystem.md
@@ -32,6 +32,8 @@ Deep Agents 的虚拟文件系统提供了 6 个核心工具：
 
 ![虚拟文件系统六大工具：ls、read_file、write_file、edit_file、glob、grep](../public/imgs/07-infographic-six-tools.png)
 
+工具定义的是 Agent **能做什么**，权限规则决定一次具体操作**是否可以做**。例如，`write_file` 和 `edit_file` 默认都是普通文件操作，但可以通过 `FilesystemPermission` 对敏感路径直接拒绝，或在执行前暂停等待人工审批。后者的完整中断与恢复流程见[第 9 章的“文件系统权限中断”](../ch09-human-in-the-loop/#文件系统权限中断)。
+
 ### `read_file`：不只是"读文件"
 
 `read_file` 有两个值得特别关注的特性。
@@ -318,6 +320,16 @@ agent = create_deep_agent(
 > 💡 `namespace` 本地需要加 `if rt.server_info else ("local-user",)` 兜底。
 
 权限规则在工具调用前按声明顺序求值，采用 first-match-wins：第一个同时匹配 `operations` 和 `paths` 的规则决定结果；如果没有规则匹配，则默认允许。因此配置权限时，应将更具体的规则放在更宽泛的规则之前。
+
+`FilesystemPermission` 的 `mode` 决定命中规则后的处理方式：
+
+| `mode` | 行为 | 适用场景 |
+|---|---|---|
+| `"allow"` | 允许操作继续执行 | 为特定路径设置显式例外 |
+| `"deny"` | 直接拒绝，不执行文件操作 | 无论谁发起都不应访问的路径 |
+| `"interrupt"` | 暂停并等待人工决策 | 可以操作，但必须先经过审批的敏感路径 |
+
+`mode="interrupt"` 需要 Checkpointer，并使用与工具审批相同的 `Command(resume=...)` 恢复协议；具体配置和恢复代码统一放在[第 9 章](../ch09-human-in-the-loop/#文件系统权限中断)。
 
 ### 实现自定义后端
 

--- a/content/ch04-task-planning.md
+++ b/content/ch04-task-planning.md
@@ -115,6 +115,19 @@ Agent 调用 write_todos 更新列表：
 
 还记得第 1 章的三层架构吗？Deep Agents（Harness）构建在 LangChain（Framework）之上。而 LangChain 提供了一套<strong>中间件（Middleware）</strong>系统——它是 Agent 能力的插件机制。`create_deep_agent()` 内部做的事情，本质上就是把一组中间件**自动组装**到了 Agent 上。
 
+### 先分清两类 Hook
+
+LangChain 中间件提供两类执行边界。它们都叫 Hook，但适合解决的问题并不相同：
+
+| 风格 | Hook | 执行方式 | 适合场景 |
+|---|---|---|---|
+| **Node-style** | `before_agent`、`before_model`、`after_model`、`after_agent` | 编译成 Agent 图中的独立节点，按生命周期顺序运行 | 校验、状态更新、审计、人工中断 |
+| **Wrap-style** | `wrap_model_call`、`wrap_tool_call` | 包裹一次模型或工具调用；可以不调用、调用一次或多次 `handler` | 重试、缓存、降级、请求或响应转换 |
+
+这个区别对 `interrupt()` 尤其重要：Node-style Hook 有清晰的图节点边界，暂停与恢复时更容易推断哪些逻辑会重放；Wrap-style Hook 位于 model/tools 节点内部，恢复时可能连同 `handler` 一起重新执行。因此自定义人工中断优先放在 Node-style Hook 中，Wrap-style 即使技术上可以调用，也不适合作为默认中断边界。
+
+第 9 章会用一个完整例子展示[如何在自定义 Middleware 的 Node-style Hook 中直接调用 `interrupt()`](../ch09-human-in-the-loop/#在自定义-middleware-中使用-interrupt)。
+
 `create_deep_agent()` 的中间件堆栈分为三层：
 
 **常驻层（始终启用，无论传入什么参数）**：

--- a/content/ch05-subagents.md
+++ b/content/ch05-subagents.md
@@ -450,4 +450,4 @@ subagents = [
 5. **结构化输出**：通过 `response_format` 让子 Agent 返回 JSON，方便主 Agent 程序化处理（需 deepagents>=0.5.3）
 6. **最佳实践**：描述要具体、提示词要详细、工具集要精简、模型按需选择、返回结果要精炼
 
-下一章（第 6 章），我们将学习 Async Subagent——异步委派与并行协同，让主 Agent 同时驱动多个子 Agent 并行工作。
+下一章（第 6 章），我们将学习 Async Subagent——异步委派与并行协同，让主 Agent 同时驱动多个子 Agent 并行工作。运行方式也会发生一次明确切换：本章示例可以直接在 Python 进程中调用 `agent.invoke()`，下一章则需要把主 Agent 和异步子 Agent 注册到 Agent Protocol 兼容的 LangGraph 服务中，再通过 thread / run 管理后台任务。

--- a/content/ch06-async-subagents.md
+++ b/content/ch06-async-subagents.md
@@ -2,7 +2,16 @@
 
 > 上一章我们学习了同步子 Agent，主 Agent 通过 `task` 工具委派、然后**等待**子 Agent 跑完。但是，当子任务要花上几分钟、甚至几十分钟时，主 Agent 在用户面前就成了“死机状态”——既无法继续聊，也无法插话调整方向。本章学习 Deep Agents 0.5.0 的预览特性：**Async Subagent（异步子 Agent）**——主 Agent 立即拿到任务 ID 就返回，子 Agent 在后台继续跑；用户可以随时问进度、追加要求，甚至中途取消。
 
-> ⚠️ Async Subagent 是 `deepagents>=0.5.0` 的**预览特性**（preview），仍在迭代中，API 可能变化。本章对应的代码示例需要运行在支持 Agent Protocol 的 LangGraph 服务环境中。起步时不必先上 LangSmith Deployments；本地单部署 + ASGI 传输就能完成最小验证。
+> ⚠️ **前置环境与运行模型变化**
+>
+> Async Subagent 是 `deepagents>=0.5.0` 的**预览特性**（preview），仍在迭代中，API 可能变化。与前几章直接在 Python 进程中调用 `agent.invoke()` 不同，本章示例需要运行在支持 Agent Protocol 的 LangGraph 服务环境中。开始前需要理解四个要素：
+>
+> - 用 `langgraph.json` 注册主 Agent 和异步子 Agent；
+> - `AsyncSubAgent.graph_id` 必须与配置中的 graph 名称一致；
+> - 用 `langgraph dev` 启动本地 Agent Server；
+> - 为并行任务预留足够的 worker slots（`--n-jobs-per-worker`）。
+>
+> 起步时不需要远程部署：本章后面会给出“本地单部署 + ASGI”的完整最小示例。
 
 ## 同步子 Agent 的瓶颈
 

--- a/content/ch09-human-in-the-loop.md
+++ b/content/ch09-human-in-the-loop.md
@@ -367,7 +367,7 @@ interrupt_on = {
 
 ## 文件系统权限中断
 
-除了 `interrupt_on`，Deep Agents 的内置文件系统工具也可以通过权限规则触发中断。这个能力需要 `deepagents>=0.6.8`。当 `write_file` 或 `edit_file` 命中 `mode="interrupt"` 的权限规则时，Deep Agents 会抛出和普通工具审批相同格式的 HITL 中断：
+除了 `interrupt_on`，Deep Agents 的内置文件系统工具也可以通过权限规则触发中断。这个能力需要 `deepagents>=0.6.8`。第 3 章介绍的 [`write_file` 和 `edit_file`](../ch03-virtual-filesystem/#六大文件系统工具) 在命中 `mode="interrupt"` 的权限规则时，Deep Agents 会抛出和普通工具审批相同格式的 HITL 中断：
 
 ```python
 from deepagents import FilesystemPermission, create_deep_agent

--- a/content/ch09-human-in-the-loop.md
+++ b/content/ch09-human-in-the-loop.md
@@ -21,6 +21,8 @@ Agent 的自主性是一把双刃剑：
 
 Deep Agents 通过 `interrupt_on` 参数配置哪些工具需要人工审批。设置后，Deep Agents 会在默认中间件栈中加入 `HumanInTheLoopMiddleware`；如果运行在工具返回前被中断或取消，同一栈里的 `PatchToolCallsMiddleware` 会自动修复消息历史。
 
+`interrupt_on` 是“工具调用审批”的便捷入口，不是 HITL 的能力边界。当暂停点不对应某个工具——例如发布最终答复前审稿、进入下一阶段前确认，或跨多个工具统一执行策略——可以在自定义 LangChain Middleware 中直接调用底层 `interrupt()`。Deep Agents 的 `middleware=[...]` 参数允许把这类能力注入现有 Harness。
+
 ```python
 import os
 from langchain_openai import ChatOpenAI
@@ -388,7 +390,7 @@ agent = create_deep_agent(
 
 ## 揭开引擎盖：LangGraph 的中断机制
 
-`interrupt_on` 的底层是 LangGraph 的<strong>中断（Interrupt）</strong>原语。当你在工具中直接调用 `interrupt()` 函数时，可以实现更灵活的审批逻辑：
+`interrupt_on` 的底层是 LangGraph 的<strong>中断（Interrupt）</strong>原语。当你在工具或图节点中直接调用 `interrupt()` 函数时，可以实现更灵活的审批逻辑：
 
 ```python
 from langgraph.types import interrupt
@@ -428,7 +430,81 @@ result = agent.invoke(
 )
 ```
 
-`interrupt()` 是 LangGraph 的底层能力，`interrupt_on` 是 Deep Agents 在此基础上封装的更易用的配置接口。
+`interrupt()` 是 LangGraph 的底层能力，`interrupt_on` 是 Deep Agents 在此基础上封装的工具审批接口。
+
+### 在自定义 Middleware 中使用 interrupt()
+
+LangChain 的 Node-style Middleware Hook 会成为 Agent 图中的独立节点，因此可以直接调用 `interrupt()`。官方 `HumanInTheLoopMiddleware` 本身就是这样实现的：在 `after_model` 中检查模型提出的工具调用，再通过 `interrupt()` 暂停。
+
+下面的例子不审批某个工具，而是在模型生成最终草稿后、结果交付给用户前统一审稿。这类跨工具策略无法只靠 `interrupt_on` 表达，却可以作为自定义 Middleware 注入 Deep Agents：
+
+```python
+from typing import Any
+
+from deepagents import create_deep_agent
+from langchain.agents.middleware import AgentMiddleware, AgentState
+from langchain.messages import AIMessage
+from langgraph.checkpoint.memory import MemorySaver
+from langgraph.runtime import Runtime
+from langgraph.types import Command, interrupt
+
+
+class DraftApprovalMiddleware(AgentMiddleware):
+    def after_model(
+        self,
+        state: AgentState,
+        runtime: Runtime,
+    ) -> dict[str, Any] | None:
+        last_message = state["messages"][-1]
+
+        # 有工具调用时让 Agent 继续执行；这里只审查最终草稿。
+        if not isinstance(last_message, AIMessage) or last_message.tool_calls:
+            return None
+
+        decision = interrupt({
+            "type": "draft_review",
+            "draft": last_message.content,
+            "message": "是否批准向用户发布这份草稿？",
+        })
+
+        if decision.get("approved"):
+            return None
+
+        reason = decision.get("reason", "审批未通过")
+        return {
+            "messages": [AIMessage(content=f"草稿未发布：{reason}")],
+        }
+
+
+agent = create_deep_agent(
+    model=model,
+    middleware=[DraftApprovalMiddleware()],
+    checkpointer=MemorySaver(),
+)
+
+config = {"configurable": {"thread_id": "draft-review-001"}}
+
+paused = agent.invoke(
+    {"messages": [{"role": "user", "content": "起草一份上线公告"}]},
+    config=config,
+    version="v2",
+)
+
+final = agent.invoke(
+    Command(resume={"approved": True}),
+    config=config,
+    version="v2",
+)
+```
+
+`before_model`、`after_model` 等 Node-style Hook 是推荐的中断位置。Wrap-style Hook 中虽然也能调用 `interrupt()`，但它运行在 model/tools 节点内部，而且 `handler` 可能被跳过、执行一次或因重试执行多次。如果在 `handler()` 之后中断，恢复时整个所在节点会从头重放，模型调用或工具调用也可能再次发生。因此 Wrap-style 更适合重试、缓存和转换，不应作为常规人工中断边界。
+
+| 需求 | 推荐位置 | 原因 |
+|---|---|---|
+| 调用模型前补充缺失信息 | `before_model` | 模型运行前暂停，边界清楚 |
+| 模型生成结果后统一审查 | `after_model` | 可检查模型输出或工具调用计划 |
+| 整次 Agent 运行前后确认 | `before_agent` / `after_agent` | 适合会话级策略 |
+| 重试、缓存、模型降级 | `wrap_model_call` / `wrap_tool_call` | 需要控制 `handler`，不以人工暂停为主 |
 
 ### 运行时视角：一次中断到底保存了什么？
 
@@ -658,12 +734,13 @@ graph.invoke(None, config=config)     # 传入 None 继续执行
 
 ### 什么时候直接使用底层 interrupt()？
 
-Deep Agents 的 `interrupt_on` 已经覆盖了大多数"工具调用前审批"场景。只有当你要控制**图节点级别**的流程时，才需要直接使用 `interrupt()`：
+Deep Agents 的 `interrupt_on` 已经覆盖了大多数“工具调用前审批”场景。当暂停点不属于单个工具，或需要在自定义业务节点、Middleware 生命周期中控制流程时，再直接使用 `interrupt()`：
 
 | 场景 | 推荐方式 | 原因 |
 |---|---|---|
 | 给某个工具加审批 | `interrupt_on` | 配置简单，自动生成 action request 和 ToolMessage |
 | 按工具参数决定是否审批 | `interrupt_on` + `when` | 保留 Deep Agents 的工具审查格式 |
+| 在模型调用前后统一审查 | Node-style Middleware + `interrupt()` | 可作为自定义能力注入 Deep Agents，不受单个工具限制 |
 | 在节点中收集缺失信息 | 直接调用 `interrupt()` | 不是工具审批，而是业务流程缺字段 |
 | 做多轮表单/输入验证 | 直接调用 `interrupt()` + 条件边 | 每次只暂停一次，无效输入通过状态回路重新提问 |
 | 调试图执行路径 | `interrupt_before` / `interrupt_after` | 静态断点不需要改节点代码 |
@@ -682,7 +759,8 @@ Deep Agents 的 `interrupt_on` 已经覆盖了大多数"工具调用前审批"�
 5. **子 Agent 独立配置**：子 Agent 可以有比主 Agent 更严格的审批策略
 6. **按风险分层**：高风险审批/修改/拒绝、中风险审批/拒绝、低风险无需中断
 7. **文件系统权限中断**：用 `FilesystemPermission(..., mode="interrupt")` 保护敏感路径
-8. **底层机制**：`interrupt()` 通过异常暂停 + Checkpointer 保存状态 + 恢复时节点从头执行。核心规则：不要裸 try/except、副作用要幂等、不要动态改变调用顺序，并行中断用 ID 映射恢复
-9. **扩展模式**：输入验证（单次 interrupt + 条件边回到节点）、静态中断（调试用 interrupt_before/after）
+8. **自定义 Middleware 中断**：Node-style Hook 可以直接使用 `interrupt()`，并通过 `middleware=[...]` 注入 Deep Agents；Wrap-style 不适合作为默认中断边界
+9. **底层机制**：`interrupt()` 通过异常暂停 + Checkpointer 保存状态 + 恢复时节点从头执行。核心规则：不要裸 try/except、副作用要幂等、不要动态改变调用顺序，并行中断用 ID 映射恢复
+10. **扩展模式**：输入验证（单次 interrupt + 条件边回到节点）、静态中断（调试用 interrupt_before/after）
 
 下一章，我们将学习沙箱执行——让 Agent 在受控环境中安全地运行代码。


### PR DESCRIPTION
## 变更内容

### #80：补充 Middleware 中直接使用 `interrupt()`

- 在第 4 章区分 Node-style 与 Wrap-style Hook 的执行边界
- 明确 `interrupt_on` 是工具审批的便捷接口，不是 HITL 的能力边界
- 在第 9 章增加可注入 Deep Agents 的 `after_model + interrupt()` 自定义 Middleware 示例
- 说明 Node-style 适合作为人工中断边界，Wrap-style 因 handler 重试与节点重放不适合作为默认选择
- 保留并强化 replay、幂等性、稳定调用顺序和 Checkpointer 要求

实现方式依据当前 [LangChain Custom Middleware 文档](https://docs.langchain.com/oss/python/langchain/middleware/custom) 和 [DeepAgents `create_deep_agent` API](https://reference.langchain.com/python/deepagents/graph/create_deep_agent)。

### #83：连接文件工具与 HITL 权限

- 在第 3 章解释文件工具能力与权限策略的分工
- 补充 `allow`、`deny`、`interrupt` 三种权限模式
- 在第 3、9 章之间增加双向锚点链接

### #81：说明第 6 章运行环境变化

- 在第 5 章末尾提示从进程内 `agent.invoke()` 切换到 Agent Protocol 服务模式
- 在第 6 章顶部列出 `langgraph.json`、`graph_id`、`langgraph dev` 和 worker slots 四项前置要素
- 明确本地单部署 + ASGI 即可开始，不要求远程部署

三个 issue 分别保留为三个独立 commit，便于审阅。

## 验证

- `npm run build`：13 个页面构建成功
- 已检查第 3→9、4→9、9→3 章生成后的链接与标题锚点
- 已确认第 6 章前置环境提示出现在生产构建产物中

Closes #80
Closes #81
Closes #83
