### PR TITLE
docs: improve Windows setup and add install CI

### DIFF
--- a/.github/workflows/cross-platform-install.yml
+++ b/.github/workflows/cross-platform-install.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Install uv on Unix
         if: runner.os != 'Windows'
@@ -47,7 +49,7 @@ jobs:
         shell: powershell
         run: |
           irm https://cli.langsmith.com/install.ps1 | iex
-          "$HOME\.local\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          (Join-Path $HOME "AppData\Local\Programs\langsmith\bin") | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Verify CLI installations on Unix
         if: runner.os != 'Windows'

--- a/.github/workflows/cross-platform-install.yml
+++ b/.github/workflows/cross-platform-install.yml
@@ -1,0 +1,90 @@
+name: Cross-platform installation
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify-installation:
+    name: ${{ matrix.label }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            label: Ubuntu (WSL2 equivalent)
+          - os: macos-latest
+            label: macOS
+          - os: windows-latest
+            label: Windows PowerShell 5.1
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Install uv on Unix
+        if: runner.os != 'Windows'
+        shell: bash
+        run: curl -LsSf https://astral.sh/uv/install.sh | sh
+
+      - name: Install uv on Windows
+        if: runner.os == 'Windows'
+        shell: powershell
+        run: powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
+
+      - name: Install LangSmith CLI on Unix
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          curl -fsSL https://cli.langsmith.com/install.sh | sh
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Install LangSmith CLI on Windows
+        if: runner.os == 'Windows'
+        shell: powershell
+        run: |
+          irm https://cli.langsmith.com/install.ps1 | iex
+          "$HOME\.local\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+      - name: Verify CLI installations on Unix
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          uv --version
+          uvx --version
+          langsmith --version
+
+      - name: Verify CLI installations on Windows
+        if: runner.os == 'Windows'
+        shell: powershell
+        run: |
+          uv --version
+          uvx --version
+          langsmith --version
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: '22.12.0'
+          cache: npm
+
+      - name: Install site dependencies
+        run: npm ci
+
+      - name: Test CI contract
+        run: npm run ci:test
+
+      - name: Test Windows documentation
+        run: npm run docs:test
+
+      - name: Test asset helpers
+        run: npm run assets:test
+
+      - name: Validate assets
+        run: npm run assets:check
+
+      - name: Build site
+        run: npm run build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,6 +123,22 @@ docs: 改善第 X 章 <简要说明>
 
 ---
 
+## 跨平台安装验证
+
+维护者可以在 GitHub Actions 中手动运行 `Cross-platform installation` 工作流。它只响应 `workflow_dispatch`，不会随 push、Pull Request 或定时任务自动运行。
+
+GitHub 要求手动工作流文件已经存在于默认分支。因此，首次引入该工作流的 PR 合并后，维护者才能从 Actions 页面选择要验证的分支或 ref 并运行它。
+
+工作流的三个矩阵项分别覆盖：
+
+- `ubuntu-latest`：验证与 Windows 学员推荐的 WSL2 环境等价的 Linux 路径；
+- `macos-latest`：验证 macOS 原生路径；
+- `windows-latest`：验证 Windows PowerShell 5.1 原生路径。
+
+每个平台都会从外部服务下载 uv、LangSmith CLI 和 npm 依赖。即使待测 ref 没有变化，上游发布服务或网络故障也可能导致对应平台失败；重试前请先查看失败步骤与安装器输出。
+
+---
+
 ## 提问与讨论
 
 - **课程内容问题**：请在 GitHub Issues 中提问，或在对应 B 站视频评论区留言

--- a/content/pre01-agentseek-create.md
+++ b/content/pre01-agentseek-create.md
@@ -28,13 +28,32 @@ AgentSeek 是一个面向 AI 应用开发的模板与生命周期工具。你通
 | uv | 当前稳定版 | 安装 CLI 和 Python 依赖 |
 | Node.js、npm | 当前 LTS 版本 | 运行 React 前端 |
 
-安装 `uv`：
+### Windows 学员：优先使用 WSL2
+
+本课程命令以 Bash 环境为主。Windows 10 2004+ 或 Windows 11 学员推荐使用 WSL2 + Ubuntu，这样可以直接执行后续的 macOS / Linux / WSL2 命令。请在**管理员 PowerShell** 中安装：
+
+```powershell
+wsl --install
+```
+
+安装完成后重启 Windows，首次打开 Ubuntu 时按提示创建 Linux 用户名和密码。再在 PowerShell 中确认发行版使用 WSL 2，并进入 Ubuntu：
+
+```powershell
+wsl -l -v
+wsl -d Ubuntu
+```
+
+如果 `wsl -l -v` 显示版本为 1，请参考 [Microsoft WSL 安装文档](https://learn.microsoft.com/windows/wsl/install) 升级到 WSL 2。使用 WSL2 的 Linux 工具时，建议把项目放在 `~/projects/` 等 Linux 文件系统目录，不要放在 `/mnt/c/` 下；也不要混用 Windows 与 WSL 中的 Python、uv、Node.js、npm 或 Git。详见 [Microsoft WSL 开发环境指南](https://learn.microsoft.com/windows/wsl/setup/environment)。
+
+如果设备策略、管理员权限或虚拟化条件不允许安装 WSL2，可以留在原生 Windows PowerShell 中，并使用本文标出的 PowerShell 命令。
+
+macOS / Linux / WSL2 安装 `uv`：
 
 ```bash
 curl -LsSf https://astral.sh/uv/install.sh | sh
 ```
 
-Windows PowerShell：
+原生 Windows PowerShell 安装 `uv`：
 
 ```powershell
 powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
@@ -45,6 +64,20 @@ powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | ie
 ```bash
 uv tool install agentseek
 ```
+
+原生 Windows PowerShell 如果提示 uv 的工具目录不在 PATH，运行：
+
+```powershell
+uv tool update-shell
+```
+
+然后关闭并重新打开 PowerShell，再执行后面的版本检查。如果只想让当前会话立即生效，可以临时加入 uv 返回的工具目录：
+
+```powershell
+$env:Path = "$(uv tool dir --bin);$env:Path"
+```
+
+临时写法不会永久修改 PATH。`uv tool update-shell` 的行为以 [uv 官方 CLI 文档](https://docs.astral.sh/uv/reference/cli/) 为准。
 
 如果你已经安装过当前包，可以升级：
 
@@ -377,9 +410,21 @@ git config --global --unset http.proxy
 
 如果 Python 依赖下载较慢，可以临时为单次同步指定团队批准的 PyPI 镜像。下面的阿里云地址在 2026 年 7 月 15 日验证可用：
 
+macOS / Linux / WSL2：
+
 ```bash
 UV_INDEX_URL=https://mirrors.aliyun.com/pypi/simple agentseek task sync
 ```
+
+原生 Windows PowerShell（建议在新开的临时终端中运行）：
+
+```powershell
+$env:UV_INDEX_URL = "https://mirrors.aliyun.com/pypi/simple"
+agentseek task sync
+Remove-Item Env:UV_INDEX_URL -ErrorAction SilentlyContinue
+```
+
+如果设置前当前终端已经有 `UV_INDEX_URL`，不要执行最后的删除命令；请在同步后恢复原值，或直接关闭专门为本次同步打开的终端。
 
 这只改变 `sync` 任务的 Python 包来源，不会解决 GitHub、SiliconFlow 或 Tavily 的连接问题。npm registry 同理；镜像服务会变化，请在使用前重新验证来源和可用性。
 

--- a/content/pre02-agentseek-skills.md
+++ b/content/pre02-agentseek-skills.md
@@ -4,6 +4,8 @@
 >
 > 本文命令于 2026-07-15 验证。Skills CLI 会继续更新；请以 `npx skills --help` 的输出为准。
 
+> Windows 学员请沿用上一章选择的环境：WSL2 用户执行本文的 macOS / Linux / WSL2（Bash）命令；留在原生 Windows 的学员执行对应的 PowerShell 命令。不要在同一个项目中混用两套 Python、Node.js 或 Git 环境。
+
 ## 两类 Skill 的区别
 
 本章安装的是编码助手开发技能。它们帮助 Codex、Claude Code、Cursor 等工具修改和调试项目。
@@ -135,22 +137,65 @@ ls .agents/skills/langsmith-trace/SKILL.md
 
 ### 5.1 检查 CLI 和认证
 
-先确认 LangSmith CLI 是否可用：
+先确认 LangSmith CLI 是否可用。
+
+macOS / Linux / WSL2：
 
 ```bash
 command -v langsmith
 langsmith --version
 ```
 
-如果命令不存在，请让编码助手使用 `langsmith-trace` 中的安装步骤，不要自行猜测安装命令。
+原生 Windows PowerShell：
 
-LangSmith CLI 从环境变量读取凭证。请在项目根目录加载 `.env`：
+```powershell
+if (Get-Command langsmith -ErrorAction SilentlyContinue) {
+  langsmith --version
+} else {
+  Write-Warning "LangSmith CLI 未安装，请先执行下面的 Windows 安装步骤。"
+}
+```
+
+如果命令不存在，使用 LangSmith CLI 官方安装脚本。
+
+macOS / Linux / WSL2：
+
+```bash
+curl -fsSL https://cli.langsmith.com/install.sh | sh
+```
+
+原生 Windows PowerShell：
+
+```powershell
+irm https://cli.langsmith.com/install.ps1 | iex
+```
+
+安装完成后关闭并重新打开终端，再运行 `langsmith --version`。如果仍然找不到命令，请按安装器输出修复 PATH。安装脚本与最新版本见 [LangSmith CLI 官方仓库](https://github.com/langchain-ai/langsmith-cli)。
+
+PyPI 的 `langsmith` 包是 Python SDK，不提供这里使用的 CLI 可执行文件；不要使用 `uv tool install langsmith` 安装 LangSmith CLI。
+
+LangSmith CLI 从环境变量读取凭证。请在项目根目录加载 `.env`。
+
+macOS / Linux / WSL2：
 
 ```bash
 set -a
 source .env
 set +a
 ```
+
+原生 Windows PowerShell：
+
+```powershell
+Get-Content .env | ForEach-Object {
+  if ($_ -match '^\s*([A-Za-z_][A-Za-z0-9_]*)=(.*)$') {
+    $value = $matches[2] -replace '^"(.*)"$', '$1'
+    Set-Item -Path "Env:$($matches[1])" -Value $value
+  }
+}
+```
+
+PowerShell 片段只加载本课程 `.env` 中常见的 `KEY=value` 行，并忽略注释和其他格式；它不会把 `.env` 当作 PowerShell 脚本执行。
 
 确认凭证有效，并找到最近有运行记录的项目：
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "assets:check": "node scripts/validate-assets.mjs",
     "assets:test": "node --test scripts/content-images.test.mjs",
+    "docs:test": "node --test scripts/windows-docs.test.mjs",
     "assets:optimize": "bash scripts/optimize-assets.sh",
     "predev": "node scripts/prep-content.mjs",
     "dev": "astro dev",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "assets:check": "node scripts/validate-assets.mjs",
     "assets:test": "node --test scripts/content-images.test.mjs",
+    "ci:test": "node --test scripts/cross-platform-ci.test.mjs",
     "docs:test": "node --test scripts/windows-docs.test.mjs",
     "assets:optimize": "bash scripts/optimize-assets.sh",
     "predev": "node scripts/prep-content.mjs",

--- a/scripts/cross-platform-ci.test.mjs
+++ b/scripts/cross-platform-ci.test.mjs
@@ -1,0 +1,55 @@
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+
+const workflowPath = fileURLToPath(
+  new URL('../.github/workflows/cross-platform-install.yml', import.meta.url),
+);
+const workflow = existsSync(workflowPath)
+  ? readFileSync(workflowPath, 'utf8')
+  : '';
+
+test('cross-platform installation workflow is manual-only', () => {
+  assert.match(workflow, /^on:\n\s+workflow_dispatch:\s*$/m);
+  assert.doesNotMatch(workflow, /^\s+(push|pull_request|schedule):/m);
+  assert.match(workflow, /contents: read/);
+});
+
+test('workflow keeps all three platform runs independent', () => {
+  for (const runner of ['ubuntu-latest', 'macos-latest', 'windows-latest']) {
+    assert.match(workflow, new RegExp(`os: ${runner}`));
+  }
+  assert.match(workflow, /WSL2 equivalent/);
+  assert.match(workflow, /fail-fast: false/);
+  assert.match(workflow, /timeout-minutes: 30/);
+});
+
+test('workflow installs and verifies the official uv and LangSmith CLIs', () => {
+  for (const expected of [
+    'https://astral.sh/uv/install.sh',
+    'https://astral.sh/uv/install.ps1',
+    'https://cli.langsmith.com/install.sh',
+    'https://cli.langsmith.com/install.ps1',
+    'shell: powershell',
+    'uv --version',
+    'uvx --version',
+    'langsmith --version',
+  ]) {
+    assert.match(workflow, new RegExp(expected.replaceAll('.', '\\.')));
+  }
+});
+
+test('every platform installs and validates the course site', () => {
+  for (const expected of [
+    "node-version: '22.12.0'",
+    'npm ci',
+    'npm run ci:test',
+    'npm run docs:test',
+    'npm run assets:test',
+    'npm run assets:check',
+    'npm run build',
+  ]) {
+    assert.match(workflow, new RegExp(expected.replaceAll('.', '\\.')));
+  }
+});

--- a/scripts/cross-platform-ci.test.mjs
+++ b/scripts/cross-platform-ci.test.mjs
@@ -9,6 +9,10 @@ const workflowPath = fileURLToPath(
 const workflow = existsSync(workflowPath)
   ? readFileSync(workflowPath, 'utf8')
   : '';
+const contributingPath = fileURLToPath(
+  new URL('../CONTRIBUTING.md', import.meta.url),
+);
+const contributing = readFileSync(contributingPath, 'utf8');
 
 test('cross-platform installation workflow is manual-only', () => {
   assert.match(workflow, /^on:\n\s+workflow_dispatch:\s*$/m);
@@ -51,5 +55,17 @@ test('every platform installs and validates the course site', () => {
     'npm run build',
   ]) {
     assert.match(workflow, new RegExp(expected.replaceAll('.', '\\.')));
+  }
+});
+
+test('maintainers are told how and when to run cross-platform installation checks', () => {
+  for (const expected of [
+    'Cross-platform installation',
+    'workflow_dispatch',
+    '默认分支',
+    'WSL2',
+    'ubuntu-latest',
+  ]) {
+    assert.match(contributing, new RegExp(expected));
   }
 });

--- a/scripts/cross-platform-ci.test.mjs
+++ b/scripts/cross-platform-ci.test.mjs
@@ -15,9 +15,9 @@ const contributingPath = fileURLToPath(
 const contributing = readFileSync(contributingPath, 'utf8');
 
 test('cross-platform installation workflow is manual-only', () => {
-  assert.match(workflow, /^on:\n\s+workflow_dispatch:\s*$/m);
-  assert.doesNotMatch(workflow, /^\s+(push|pull_request|schedule):/m);
+  assert.match(workflow, /^on:\n  workflow_dispatch:\n\npermissions:/m);
   assert.match(workflow, /contents: read/);
+  assert.match(workflow, /persist-credentials: false/);
 });
 
 test('workflow keeps all three platform runs independent', () => {
@@ -42,6 +42,7 @@ test('workflow installs and verifies the official uv and LangSmith CLIs', () => 
   ]) {
     assert.match(workflow, new RegExp(expected.replaceAll('.', '\\.')));
   }
+  assert.match(workflow, /AppData\\Local\\Programs\\langsmith\\bin/);
 });
 
 test('every platform installs and validates the course site', () => {

--- a/scripts/windows-docs.test.mjs
+++ b/scripts/windows-docs.test.mjs
@@ -27,3 +27,18 @@ test('pre01 documents the WSL2-first and PowerShell fallback paths', async () =>
     '$env:UV_INDEX_URL = "https://mirrors.aliyun.com/pypi/simple"',
   ]);
 });
+
+test('pre02 documents LangSmith CLI and dotenv steps for both shells', async () => {
+  const markdown = await readMarkdown('../content/pre02-agentseek-skills.md');
+
+  assertContainsAll(markdown, [
+    'WSL2 用户',
+    'command -v langsmith',
+    'Get-Command langsmith -ErrorAction SilentlyContinue',
+    'https://cli.langsmith.com/install.sh',
+    'https://cli.langsmith.com/install.ps1',
+    'Get-Content .env | ForEach-Object',
+    'Set-Item -Path "Env:$($matches[1])" -Value $value',
+    '不要使用 `uv tool install langsmith`',
+  ]);
+});

--- a/scripts/windows-docs.test.mjs
+++ b/scripts/windows-docs.test.mjs
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+async function readMarkdown(relativePath) {
+  return readFile(new URL(relativePath, import.meta.url), 'utf8');
+}
+
+function assertContainsAll(markdown, snippets) {
+  for (const snippet of snippets) {
+    assert.ok(markdown.includes(snippet), `Expected document to include: ${snippet}`);
+  }
+}
+
+test('pre01 documents the WSL2-first and PowerShell fallback paths', async () => {
+  const markdown = await readMarkdown('../content/pre01-agentseek-create.md');
+
+  assertContainsAll(markdown, [
+    'WSL2',
+    'wsl --install',
+    'wsl -l -v',
+    'wsl -d Ubuntu',
+    '~/projects/',
+    '/mnt/c/',
+    'uv tool update-shell',
+    '$env:Path = "$(uv tool dir --bin);$env:Path"',
+    '$env:UV_INDEX_URL = "https://mirrors.aliyun.com/pypi/simple"',
+  ]);
+});

--- a/scripts/windows-docs.test.mjs
+++ b/scripts/windows-docs.test.mjs
@@ -37,6 +37,8 @@ test('pre02 documents LangSmith CLI and dotenv steps for both shells', async () 
     'Get-Command langsmith -ErrorAction SilentlyContinue',
     'https://cli.langsmith.com/install.sh',
     'https://cli.langsmith.com/install.ps1',
+    'set -a',
+    'source .env',
     'Get-Content .env | ForEach-Object',
     'Set-Item -Path "Env:$($matches[1])" -Value $value',
     '不要使用 `uv tool install langsmith`',


### PR DESCRIPTION
## 背景

Closes #94.

准备篇此前混用了 Bash 专属语法，并遗漏了 Windows 工具安装后的 PATH、LangSmith CLI 安装和 `.env` 加载方式。Windows 学员即使完成安装，也可能在 PowerShell 中遇到命令不可用或无法继续课程的问题。

## 修改内容

- 将 WSL2 + Ubuntu 设为 Windows 学员的推荐环境，并说明项目应放在 WSL Linux 文件系统中，避免混用 Windows/WSL 工具链。
- 保留原生 Windows PowerShell 5.1 备选路径，补充 uv/AgentSeek PATH、临时 PyPI 镜像、LangSmith CLI 和 `.env` 加载命令。
- 新增 Windows 文档回归测试，防止关键 WSL2、PowerShell 和 Bash 指引被后续修改误删。
- 新增仅支持 `workflow_dispatch` 的 `Cross-platform installation` 工作流：
  - `ubuntu-latest` 验证与 WSL2 等价的 Linux 安装路径；
  - `macos-latest` 验证 macOS 路径；
  - `windows-latest` 使用 Windows PowerShell 5.1 验证原生路径；
  - 每个平台实际运行 uv、LangSmith CLI 官方最新安装器，检查版本，然后执行 `npm ci`、测试、资源校验和生产构建。
- 增加 CI 契约测试和维护者手动运行说明；checkout 不持久化 Git 凭据。

## 根因与修复

- Bash 的环境变量、命令检查和 dotenv 语法不能直接复制到 PowerShell，现已按 shell 分开说明。
- uv 工具目录可能未进入 PowerShell PATH，现补充永久更新与当前会话写法。
- LangSmith CLI 不是 PyPI 的 `langsmith` Python SDK，现直接使用官方 Bash/PowerShell 安装器。
- Windows LangSmith 安装器默认写入 `$HOME\AppData\Local\Programs\langsmith\bin`；CI 将该实际目录传给后续 step，避免版本检查找不到命令。

## 本地验证

- `npm run ci:test`：5/5 通过
- `npm run docs:test`：2/2 通过
- `npm run assets:test`：3/3 通过
- `npm run assets:check`：41 张位图、16 份 PDF、40 个内容图片引用通过校验
- `npm run build`：15 个页面构建成功
- GitHub Actions YAML 语法解析通过
- `git diff --check 6cc87def..HEAD` 通过
- 独立代码复审无遗留 Critical/Important 问题

## 已知验证边界

GitHub 要求 `workflow_dispatch` 工作流已经存在于默认分支，因此首次引入该工作流的 PR 无法在合并前执行三平台 Runner。本 PR 没有声称远程三平台安装已经成功。

合并后请在 Actions 页面手动运行一次 `Cross-platform installation`，并检查 Ubuntu、macOS、Windows 三个矩阵结果。原生 PowerShell 命令在 PR 阶段基于 #94 实测反馈与官方安装器源码核对，并由静态回归测试覆盖。
