### PR TITLE
feat: add chapter-linked AgentSeek experiments

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,33 +61,155 @@ npx skills add ob-labs/agentseek --skill langsmith-trace
 - [AgentSeek 生命周期工作流](https://datawhalechina.github.io/deepagents-in-action/chapters/pre01-agentseek-create/)：创建 DeepAgents 模板，检查环境并启动前后端
 - [`npx skills` 安装开发技能](https://datawhalechina.github.io/deepagents-in-action/chapters/pre02-agentseek-skills/)：为 AI 编码助手加载 LangChain 工程经验
 
+### 按章节开始实验
+
+每个章节卡片都标出了最合适的 AgentSeek 模板和适配理由；README 也按同样的章节顺序列出，读到哪一章就从哪一行开始实验。第 6、8、9、11 章需要在模板基础上按正文补充本章能力，具体步骤以章节内容为准。
+
+先升级 AgentSeek，并确认 `main` 分支当前有哪些模板：
+
+```bash
+uv tool install --upgrade agentseek
+agentseek create --list-templates --checkout main
+```
+
+进入生成目录后，所有模板遵循同一套生命周期入口：
+
+```bash
+cd <生成的项目目录>
+agentseek info
+agentseek task --list
+
+# 按 task --list 的输出完成依赖安装，并按项目 README 配置 .env
+agentseek doctor
+agentseek dev
+```
+
+`--checkout main` 用于获取最新批次模板，适合跟课实验；如果需要冻结作业环境，请将 `main` 换成记录下来的完整提交 SHA。
+
 ### 认知篇
 
-| 章节 | 标题 |
-|------|------|
-| 第 1 章 | [从 Agent Framework 到 Agent Harness — Deep Agents 的诞生逻辑](https://datawhalechina.github.io/deepagents-in-action/chapters/ch01-agent-harness/) |
-| 第 2 章 | [快速上手 — 5 分钟构建你的第一个 Deep Agent](https://datawhalechina.github.io/deepagents-in-action/chapters/ch02-quickstart/) |
+#### 第 1 章：[从 Agent Framework 到 Agent Harness — Deep Agents 的诞生逻辑](https://datawhalechina.github.io/deepagents-in-action/chapters/ch01-agent-harness/)
+
+- 模板：[`deepagents/default`](https://github.com/agentseek-ai/agentseek-templates/tree/main/templates/deepagents/default)
+- 实验：从最小 `create_deep_agent` 项目识别 Runtime、Framework 与 Harness 的边界。
+
+```bash
+agentseek create deepagents/default --checkout main --no-input
+```
+
+#### 第 2 章：[快速上手 — 5 分钟构建你的第一个 Deep Agent](https://datawhalechina.github.io/deepagents-in-action/chapters/ch02-quickstart/)
+
+- 模板：[`deepagents/default`](https://github.com/agentseek-ai/agentseek-templates/tree/main/templates/deepagents/default)
+- 实验：修改系统提示词和自定义工具，跑通第一个可工作的 Deep Agent。
+
+```bash
+agentseek create deepagents/default --checkout main --no-input
+```
 
 ### 核心篇
 
-| 章节 | 标题 |
-|------|------|
-| 第 3 章 | [虚拟文件系统 — Deep Agents 的 Context Engineering 核心](https://datawhalechina.github.io/deepagents-in-action/chapters/ch03-virtual-filesystem/) |
-| 第 4 章 | [任务规划与分解 — 让 Agent 学会拆解复杂任务](https://datawhalechina.github.io/deepagents-in-action/chapters/ch04-task-planning/) |
-| 第 5 章 | [子 Agent 与上下文隔离 — 让 Agent 学会委派](https://datawhalechina.github.io/deepagents-in-action/chapters/ch05-subagents/) |
-| 第 6 章 | [异步子 Agent — 让主 Agent 同时驱动多个子任务](https://datawhalechina.github.io/deepagents-in-action/chapters/ch06-async-subagents/) |
+#### 第 3 章：[虚拟文件系统 — Deep Agents 的 Context Engineering 核心](https://datawhalechina.github.io/deepagents-in-action/chapters/ch03-virtual-filesystem/)
+
+- 模板：[`deepagents/content-builder`](https://github.com/agentseek-ai/agentseek-templates/tree/main/templates/deepagents/content-builder)
+- 实验：利用现成 `FilesystemBackend` 观察内容、中间结果和 Skills 如何落盘。
+
+```bash
+agentseek create deepagents/content-builder --checkout main --no-input
+```
+
+#### 第 4 章：[任务规划与分解 — 让 Agent 学会拆解复杂任务](https://datawhalechina.github.io/deepagents-in-action/chapters/ch04-task-planning/)
+
+- 模板：[`deepagents/research`](https://github.com/agentseek-ai/agentseek-templates/tree/main/templates/deepagents/research)
+- 实验：通过 Todo 面板观察 `write_todos` 的计划生成与状态变化。
+
+```bash
+agentseek create deepagents/research --checkout main --no-input
+```
+
+#### 第 5 章：[子 Agent 与上下文隔离 — 让 Agent 学会委派](https://datawhalechina.github.io/deepagents-in-action/chapters/ch05-subagents/)
+
+- 模板：[`deepagents/research`](https://github.com/agentseek-ai/agentseek-templates/tree/main/templates/deepagents/research)
+- 实验：观察主 Agent 将搜索委派给 research-agent，并比较两侧上下文。
+
+```bash
+agentseek create deepagents/research --checkout main --no-input
+```
+
+#### 第 6 章：[异步子 Agent — 让主 Agent 同时驱动多个子任务](https://datawhalechina.github.io/deepagents-in-action/chapters/ch06-async-subagents/)
+
+- 模板：[`deepagents/research`](https://github.com/agentseek-ai/agentseek-templates/tree/main/templates/deepagents/research)
+- 实验：从同步研究应用开始，按本章将 researcher 拆成独立 graph 并接入 `AsyncSubAgent`。
+
+```bash
+agentseek create deepagents/research --checkout main --no-input
+```
 
 ### 进阶篇
 
-| 章节 | 标题 |
-|------|------|
-| 第 7 章 | [Skills — 可复用的 Agent 能力包](https://datawhalechina.github.io/deepagents-in-action/chapters/ch07-skills/) |
-| 第 8 章 | [长期记忆 — 让 Agent 拥有跨对话的记忆](https://datawhalechina.github.io/deepagents-in-action/chapters/ch08-long-term-memory/) |
-| 第 9 章 | [Human-in-the-Loop — 构建安全的人机协作流程](https://datawhalechina.github.io/deepagents-in-action/chapters/ch09-human-in-the-loop/) |
-| 第 10 章 | [沙箱执行 — 让 Agent 安全地运行代码](https://datawhalechina.github.io/deepagents-in-action/chapters/ch10-sandboxes/) |
-| 第 11 章 | [文件系统权限 — 用声明式规则控制 Agent 的读写边界](https://datawhalechina.github.io/deepagents-in-action/chapters/ch11-filesystem-permissions/) |
-| 第 12 章 | [MCP — 用标准协议扩展 Deep Agents 工具生态](https://datawhalechina.github.io/deepagents-in-action/chapters/ch12-mcp/) |
-| 第 13 章 | [Grading Rubrics（评分量规）— 让 Agent 按验收标准自我迭代](https://datawhalechina.github.io/deepagents-in-action/chapters/ch13-grading-rubrics/) |
+#### 第 7 章：[Skills — 可复用的 Agent 能力包](https://datawhalechina.github.io/deepagents-in-action/chapters/ch07-skills/)
+
+- 模板：[`deepagents/content-builder`](https://github.com/agentseek-ai/agentseek-templates/tree/main/templates/deepagents/content-builder)
+- 实验：使用内置 blog-post 与 social-media Skills 观察匹配和渐进式加载。
+
+```bash
+agentseek create deepagents/content-builder --checkout main --no-input
+```
+
+#### 第 8 章：[长期记忆 — 让 Agent 拥有跨对话的记忆](https://datawhalechina.github.io/deepagents-in-action/chapters/ch08-long-term-memory/)
+
+- 模板：[`deepagents/content-builder`](https://github.com/agentseek-ai/agentseek-templates/tree/main/templates/deepagents/content-builder)
+- 实验：从内容应用开始，按本章加入 `CompositeBackend`、`StoreBackend` 和运行时 namespace。
+
+```bash
+agentseek create deepagents/content-builder --checkout main --no-input
+```
+
+#### 第 9 章：[Human-in-the-Loop — 构建安全的人机协作流程](https://datawhalechina.github.io/deepagents-in-action/chapters/ch09-human-in-the-loop/)
+
+- 模板：[`deepagents/mcp`](https://github.com/agentseek-ai/agentseek-templates/tree/main/templates/deepagents/mcp)
+- 实验：从 MCP 应用开始，按本章为有副作用的工具配置 `interrupt_on`。
+
+```bash
+agentseek create deepagents/mcp --checkout main --no-input
+```
+
+#### 第 10 章：[沙箱执行 — 让 Agent 安全地运行代码](https://datawhalechina.github.io/deepagents-in-action/chapters/ch10-sandboxes/)
+
+- 模板：[`deepagents/sandbox`](https://github.com/agentseek-ai/agentseek-templates/tree/main/templates/deepagents/sandbox)
+- 实验：选择 Daytona 或 LangSmith Sandbox，观察隔离执行、文件读写与清理。
+
+```bash
+agentseek create deepagents/sandbox --checkout main --no-input
+```
+
+#### 第 11 章：[文件系统权限 — 用声明式规则控制 Agent 的读写边界](https://datawhalechina.github.io/deepagents-in-action/chapters/ch11-filesystem-permissions/)
+
+- 模板：[`deepagents/content-builder`](https://github.com/agentseek-ai/agentseek-templates/tree/main/templates/deepagents/content-builder)
+- 实验：从真实内容目录开始，按本章加入 `FilesystemPermission` 并划分访问边界。
+
+```bash
+agentseek create deepagents/content-builder --checkout main --no-input
+```
+
+#### 第 12 章：[MCP — 用标准协议扩展 Deep Agents 工具生态](https://datawhalechina.github.io/deepagents-in-action/chapters/ch12-mcp/)
+
+- 模板：[`deepagents/mcp`](https://github.com/agentseek-ai/agentseek-templates/tree/main/templates/deepagents/mcp)
+- 实验：验证 stdio/HTTP Server、工具发现、稳定前缀与名称冲突。
+
+```bash
+agentseek create deepagents/mcp --checkout main --no-input
+```
+
+### 前沿预览
+
+#### 第 13 章：[Grading Rubrics（评分量规）— 让 Agent 按验收标准自我迭代](https://datawhalechina.github.io/deepagents-in-action/chapters/ch13-grading-rubrics/)
+
+- 模板：[`langchain/rubric`](https://github.com/agentseek-ai/agentseek-templates/tree/main/templates/langchain/rubric)
+- 实验：先运行无需模型密钥的 Guided Demo，再观察 Evidence 与 Acceptance Gate。
+
+```bash
+agentseek create langchain/rubric --checkout main --no-input
+```
 
 后续课程内容将根据 Deep Agents 的官方能力演进持续更新。
 

--- a/content/pre01-agentseek-create.md
+++ b/content/pre01-agentseek-create.md
@@ -2,7 +2,7 @@
 
 > 完成本章后，你会得到一个可运行的 DeepAgents 研究应用。AgentSeek 会负责检查环境、安装项目依赖并启动前后端。
 >
-> 本文命令于 2026-07-15 验证。AgentSeek 和模板会继续更新；如果任务名称与本文不同，以 `agentseek task --list` 的输出为准。
+> 本文命令于 2026-08-18 使用 AgentSeek `0.1.2` 验证。AgentSeek 和模板会继续更新；如果任务名称与本文不同，以 `agentseek task --list` 的输出为准。
 
 ## AgentSeek 管理什么
 
@@ -62,7 +62,7 @@ powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | ie
 安装 AgentSeek：
 
 ```bash
-uv tool install agentseek
+uv tool install --upgrade agentseek
 ```
 
 原生 Windows PowerShell 如果提示 uv 的工具目录不在 PATH，运行：
@@ -79,19 +79,6 @@ $env:Path = "$(uv tool dir --bin);$env:Path"
 
 临时写法不会永久修改 PATH。`uv tool update-shell` 的行为以 [uv 官方 CLI 文档](https://docs.astral.sh/uv/reference/cli/) 为准。
 
-如果你已经安装过当前包，可以升级：
-
-```bash
-uv tool upgrade agentseek
-```
-
-如果终端仍显示 `agentseek-cli 0.0.x`，先移除旧包，再安装当前包：
-
-```bash
-uv tool uninstall agentseek-cli
-uv tool install agentseek
-```
-
 确认命令已经可用：
 
 ```bash
@@ -99,23 +86,25 @@ agentseek version
 agentseek --help
 ```
 
-你应该在帮助信息中看到 `create`、`info`、`task`、`doctor` 和 `dev`。
+你应该在帮助信息中看到 `create`、`info`、`task`、`doctor` 和 `dev`。本文验证时版本输出为 `AGENTSEEK v0.1.2`；以后版本号可能不同。
 
 ## 2. 选择并创建模板
 
 查看当前 CLI 识别的模板：
 
 ```bash
-agentseek create --list-templates
+agentseek create --list-templates --checkout main
 ```
 
-模板列表会随 AgentSeek 更新。本课程使用 `deepagents/research`，它包含 DeepAgents 研究 Agent、Tavily 搜索和 React 前端。
+这会列出模板仓库 `main` 分支当前注册的模板；不加 `--checkout main` 时，列表来自当前 AgentSeek 版本锁定的目录，可能不会立即包含最新批次。本课程使用 `deepagents/research`，它包含 DeepAgents 研究 Agent、Tavily 搜索和 React 前端。
 
-创建项目并使用模板默认值：
+创建项目并从模板仓库的 `main` 分支获取最新批次模板：
 
 ```bash
-agentseek create deepagents/research --no-input
+agentseek create deepagents/research --checkout main --no-input
 ```
+
+`--checkout main` 让 AgentSeek 在创建时读取模板仓库当前的 `main` 分支，而不是只使用 CLI 内置的锁定目录。它适合跟随最新模板学习；模板更新后，生成项目的文件和依赖也可能变化。如果你需要课程作业完全复现某一次结果，再把 `main` 换成当时记录的完整提交 SHA。
 
 进入生成目录：
 
@@ -338,10 +327,10 @@ Research what LangGraph 1.0 added vs 0.x. Cite sources.
 如果终端出现 `Could not resolve host`、`Connection timed out` 或 `Failed to connect`，通常应先排查网络，而不是直接判断 AgentSeek CLI 异常。
 
 ```bash
-git ls-remote https://github.com/ob-labs/agentseek.git
+git ls-remote https://github.com/agentseek-ai/agentseek-templates.git
 ```
 
-如果连接失败，请先修复当前终端的网络或代理配置。当前 AgentSeek 仍会把远程模板仓库缓存到 `~/.cookiecutters/agentseek`；不要为了绕过连接问题直接删除或覆盖这个目录，否则可能丢失可用缓存，或长期使用一个没有更新的旧模板。
+如果连接失败，请先修复当前终端的网络或代理配置。AgentSeek 会把远程模板目录缓存到 Cookiecutter 用户目录；不要为了绕过连接问题直接删除或覆盖缓存，否则可能丢失可用缓存，或长期使用一个没有更新的旧模板。
 
 ### 为当前终端设置代理
 
@@ -430,13 +419,13 @@ Remove-Item Env:UV_INDEX_URL -ErrorAction SilentlyContinue
 
 ### 使用已经下载的模板仓库
 
-如果你在另一台能访问 GitHub 的机器上下载了 ZIP 或克隆了 AgentSeek 仓库，可以把完整目录复制到当前机器，再直接指定模板的绝对路径：
+如果你在另一台能访问 GitHub 的机器上下载了 ZIP 或克隆了 AgentSeek Templates 仓库，可以把完整目录复制到当前机器，再直接指定模板的绝对路径：
 
 ```bash
-agentseek create /absolute/path/to/agentseek/templates/deepagents/research --no-input
+agentseek create /absolute/path/to/agentseek-templates/templates/deepagents/research --no-input
 ```
 
-这条路径不会修改共享的 Cookiecutter 缓存，也不需要固定分支或 commit。当前 CLI 仍能读取 `~/.cookiecutters/agentseek`，但直接使用本地模板路径更容易看清版本，也不会覆盖其他项目正在使用的缓存。
+这条路径不会修改共享的远程模板缓存，也不需要固定分支或 commit。直接使用本地模板路径适合网络受限、但已经通过其他方式取得模板仓库的情况。
 
 本次复核中，公共加速服务 `ghproxy.net` 的 `git ls-remote` 仍能返回当前 HEAD，但完整浅克隆超过一分钟后断开。因此本章不把公共加速服务作为推荐命令；如果团队有审核过的 GitHub 镜像，可以用它下载完整仓库，再使用上面的本地路径创建项目。
 
@@ -451,4 +440,4 @@ agentseek create /absolute/path/to/agentseek/templates/deepagents/research --no-
 
 下一章将为编码助手安装 `langchain-dev-guide` 和 `langsmith-trace`，帮助你继续修改和调试这个项目。
 
-参考来源：[AgentSeek 快速开始](https://github.com/ob-labs/agentseek/blob/main/docs/get-started/index.zh.md)、[CLI 参考](https://github.com/ob-labs/agentseek/blob/main/docs/reference/cli.zh.md)、[deepagents/research 模板](https://github.com/ob-labs/agentseek/tree/main/templates/deepagents/research)、[SiliconFlow OpenAI 兼容配置](https://docs.siliconflow.cn/cn/usercases/use-siliconcloud-in-KiloCode)、[LangSmith Tracing Quickstart](https://docs.langchain.com/langsmith/observability-quickstart)。
+参考来源：[AgentSeek 快速开始](https://github.com/ob-labs/agentseek/blob/main/docs/get-started/index.zh.md)、[CLI 参考](https://github.com/ob-labs/agentseek/blob/main/docs/reference/cli.zh.md)、[AgentSeek Templates](https://github.com/agentseek-ai/agentseek-templates)、[deepagents/research 模板](https://github.com/agentseek-ai/agentseek-templates/tree/main/templates/deepagents/research)、[SiliconFlow OpenAI 兼容配置](https://docs.siliconflow.cn/cn/usercases/use-siliconcloud-in-KiloCode)、[LangSmith Tracing Quickstart](https://docs.langchain.com/langsmith/observability-quickstart)。

--- a/scripts/homepage-preview.test.mjs
+++ b/scripts/homepage-preview.test.mjs
@@ -10,6 +10,10 @@ const cardSource = await readFile(new URL('../src/components/ChapterCard.astro',
 const contentConfigSource = await readFile(new URL('../src/content.config.ts', import.meta.url), 'utf8');
 const headingSource = await readFile(new URL('../src/components/PreviewSectionHeading.astro', import.meta.url), 'utf8')
   .catch(() => '');
+const chapterExperimentSource = await readFile(
+  new URL('../src/data/chapter-experiments.mjs', import.meta.url),
+  'utf8',
+);
 
 test('Chapter 13 starts the preview-feature section', () => {
   assert.equal(manifest['ch13-grading-rubrics'].section, '前沿预览');
@@ -37,4 +41,33 @@ test('homepage registers and renders the preview section', () => {
 
 test('preview chapter cards do not repeat the section status', () => {
   assert.doesNotMatch(cardSource, /预览特性/);
+});
+
+test('homepage keeps the experiment entry inside each chapter card', () => {
+  assert.match(indexSource, /chapterExperiments/);
+  assert.match(indexSource, /experiment=\{chapterExperiments\[ch\.id\]\}/);
+  assert.match(cardSource, /本章实验/);
+  assert.match(cardSource, /data-copy=\{experiment\.command\}/);
+  assert.match(cardSource, /复制 AgentSeek 创建命令/);
+  assert.doesNotMatch(cardSource, /改造底座/);
+  assert.doesNotMatch(cardSource, /创建后/);
+  assert.doesNotMatch(cardSource, /运行说明/);
+  assert.doesNotMatch(indexSource, /TemplateLab/);
+});
+
+test('every published numbered chapter maps to exactly one current template command', async () => {
+  const { chapterExperiments } = await import('../src/data/chapter-experiments.mjs');
+  const publishedNumberedChapters = Object.entries(manifest)
+    .filter(([id, chapter]) => id.startsWith('ch') && chapter.published)
+    .map(([id]) => id)
+    .sort();
+
+  assert.deepEqual(Object.keys(chapterExperiments).sort(), publishedNumberedChapters);
+  assert.equal(new Set(Object.keys(chapterExperiments)).size, 13);
+  for (const experiment of Object.values(chapterExperiments)) {
+    assert.match(experiment.command, /^agentseek create \S+ --checkout main --no-input$/);
+    assert.match(experiment.source, /^https:\/\/github\.com\/agentseek-ai\/agentseek-templates\/tree\/main\/templates\//);
+  }
+  assert.match(chapterExperimentSource, /deepagents\/content-builder/);
+  assert.match(chapterExperimentSource, /langchain\/rubric/);
 });

--- a/src/components/ChapterCard.astro
+++ b/src/components/ChapterCard.astro
@@ -14,9 +14,15 @@ interface Props {
   description: string;
   published: boolean;
   slides?: Slide[];
+  experiment?: {
+    template: string;
+    note: string;
+    command: string;
+    source: string;
+  };
 }
 
-const { id, title, chapter, section, description, published, slides } = Astro.props;
+const { id, title, chapter, section, description, published, slides, experiment } = Astro.props;
 const base = import.meta.env.BASE_URL;
 const isExtra = section === '准备篇';
 const preMatch = isExtra && id.match(/^pre(\d+)/);
@@ -69,6 +75,23 @@ const chapterLabel = isExtra ? (preMatch ? preMatch[1] : 'EX') : String(chapter)
         </div>
       ))}
     </div>
+    {experiment && (
+      <div class="chapter-experiment">
+        <div class="chapter-experiment__main">
+          <span class="chapter-experiment__label">本章实验</span>
+          <a href={experiment.source} target="_blank" rel="noopener" class="chapter-experiment__template">
+            {experiment.template} <span aria-hidden="true">↗</span>
+          </a>
+          <button type="button" data-copy={experiment.command} aria-label={`复制第 ${chapter} 章 AgentSeek 模板创建命令`}>
+            <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M8 7V5a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2h-2M5 8h9a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-9a2 2 0 0 1 2-2Z" />
+            </svg>
+            <span data-copy-label>复制 AgentSeek 创建命令</span>
+          </button>
+        </div>
+        <p>{experiment.note}</p>
+      </div>
+    )}
   </div>
 ) : (
   <div class="relative p-6 rounded-lg border border-gold-pale/30 bg-paper-warm/50 overflow-hidden">
@@ -81,6 +104,69 @@ const chapterLabel = isExtra ? (preMatch ? preMatch[1] : 'EX') : String(chapter)
 )}
 
 <style>
+  .chapter-experiment {
+    margin-top: 1rem;
+    padding-top: 0.8rem;
+    border-top: 1px solid color-mix(in srgb, var(--color-gold) 16%, transparent);
+  }
+
+  .chapter-experiment__main {
+    display: flex;
+    align-items: center;
+    gap: 0.55rem;
+    min-width: 0;
+  }
+
+  .chapter-experiment__label {
+    flex: 0 0 auto;
+    color: var(--color-ink-muted);
+    font: 600 0.66rem/1 var(--font-sans);
+  }
+
+  .chapter-experiment__template {
+    min-width: 0;
+    overflow: hidden;
+    color: var(--color-ink);
+    font: 600 0.65rem/1.2 var(--font-mono);
+    text-decoration: none;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .chapter-experiment__template:hover { color: var(--color-gold); }
+
+  .chapter-experiment p {
+    margin: 0.4rem 0 0;
+    color: var(--color-ink-muted);
+    font-size: 0.68rem;
+    line-height: 1.5;
+  }
+
+  .chapter-experiment button {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    flex: 0 0 auto;
+    margin-left: auto;
+    padding: 0.32rem 0.46rem;
+    border: 1px solid var(--color-gold-pale);
+    border-radius: 5px;
+    color: var(--color-ink-muted);
+    background: transparent;
+    cursor: pointer;
+    font: 500 0.62rem/1 var(--font-sans);
+  }
+
+  .chapter-experiment button:hover {
+    color: var(--color-gold);
+    border-color: var(--color-gold);
+    background: color-mix(in srgb, var(--color-gold) 5%, transparent);
+  }
+
+  .chapter-experiment button:focus-visible,
+  .chapter-experiment a:focus-visible { outline: 2px solid var(--color-gold); outline-offset: 2px; }
+  .chapter-experiment svg { width: 0.75rem; height: 0.75rem; }
+
   /* 暗色模式：B站按钮 */
   :global([data-theme="dark"]) a[href*="bilibili"]:not([href*="xhs"]) {
     background: rgba(56, 189, 248, 0.15);

--- a/src/data/chapter-experiments.mjs
+++ b/src/data/chapter-experiments.mjs
@@ -1,0 +1,64 @@
+const templateSource = (template) =>
+  `https://github.com/agentseek-ai/agentseek-templates/tree/main/templates/${template}`;
+
+const experiment = (template, note) => ({
+  template,
+  note,
+  command: `agentseek create ${template} --checkout main --no-input`,
+  source: templateSource(template),
+});
+
+export const chapterExperiments = {
+  'ch01-agent-harness': experiment(
+    'deepagents/default',
+    '从最小 create_deep_agent 项目识别 Runtime、Framework 与 Harness 的边界。',
+  ),
+  'ch02-quickstart': experiment(
+    'deepagents/default',
+    '修改系统提示词和自定义工具，跑通第一个可工作的 Deep Agent。',
+  ),
+  'ch03-virtual-filesystem': experiment(
+    'deepagents/content-builder',
+    '利用现成 FilesystemBackend 观察内容、中间结果和 Skills 如何落盘。',
+  ),
+  'ch04-task-planning': experiment(
+    'deepagents/research',
+    '通过 Todo 面板直接观察 write_todos 的计划生成与状态变化。',
+  ),
+  'ch05-subagents': experiment(
+    'deepagents/research',
+    '观察主 Agent 将搜索委派给 research-agent，并比较两侧上下文。',
+  ),
+  'ch06-async-subagents': experiment(
+    'deepagents/research',
+    '从同步研究应用开始，按本章将 researcher 拆成独立 graph 并接入 AsyncSubAgent。',
+  ),
+  'ch07-skills': experiment(
+    'deepagents/content-builder',
+    '使用内置 blog-post 与 social-media Skills 观察匹配和渐进式加载。',
+  ),
+  'ch08-long-term-memory': experiment(
+    'deepagents/content-builder',
+    '从内容应用开始，按本章加入 CompositeBackend、StoreBackend 和运行时 namespace。',
+  ),
+  'ch09-human-in-the-loop': experiment(
+    'deepagents/mcp',
+    '从 MCP 应用开始，按本章为有副作用的工具配置 interrupt_on。',
+  ),
+  'ch10-sandboxes': experiment(
+    'deepagents/sandbox',
+    '选择 Daytona 或 LangSmith Sandbox，观察隔离执行、文件读写与清理。',
+  ),
+  'ch11-filesystem-permissions': experiment(
+    'deepagents/content-builder',
+    '从真实内容目录开始，按本章加入 FilesystemPermission 并划分访问边界。',
+  ),
+  'ch12-mcp': experiment(
+    'deepagents/mcp',
+    '开箱验证 stdio/HTTP Server、工具发现、稳定前缀与名称冲突。',
+  ),
+  'ch13-grading-rubrics': experiment(
+    'langchain/rubric',
+    '先运行无需模型密钥的 Guided Demo，再观察 Evidence 与 Acceptance Gate。',
+  ),
+};

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -7,6 +7,7 @@ import ChapterCard from '../components/ChapterCard.astro';
 import SectionHeading from '../components/SectionHeading.astro';
 import PreviewSectionHeading from '../components/PreviewSectionHeading.astro';
 import ChapterRail from '../components/ChapterRail.astro';
+import { chapterExperiments } from '../data/chapter-experiments.mjs';
 import '../styles/global.css';
 
 const allChapters = await getCollection('chapters');
@@ -198,6 +199,7 @@ try {
                 description={ch.data.description}
                 published={ch.data.published}
                 slides={ch.data.slides}
+                experiment={chapterExperiments[ch.id]}
                 bilibili={ch.data.bilibili}
                 xhs={ch.data.xhs}
               />
@@ -254,10 +256,16 @@ try {
     btn.addEventListener('click', () => {
       const text = (btn as HTMLElement).dataset.copy!;
       navigator.clipboard.writeText(text).then(() => {
-        const svg = btn.querySelector('svg')!;
-        const orig = svg.innerHTML;
-        svg.innerHTML = '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>';
-        setTimeout(() => { svg.innerHTML = orig; }, 1500);
+        const svg = btn.querySelector('svg');
+        const label = btn.querySelector<HTMLElement>('[data-copy-label]');
+        const originalSvg = svg?.innerHTML;
+        const originalLabel = label?.textContent;
+        if (svg) svg.innerHTML = '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>';
+        if (label) label.textContent = '已复制';
+        setTimeout(() => {
+          if (svg && originalSvg) svg.innerHTML = originalSvg;
+          if (label && originalLabel) label.textContent = originalLabel;
+        }, 1500);
       });
     });
   });


### PR DESCRIPTION
## Summary
- 将 AgentSeek 实验入口直接放入每个章节卡片的学习资源下方
- 为 13 个章节映射最新模板，并提供一键复制 `agentseek create ... --checkout main --no-input` 命令
- README 改为逐章列表与独立 bash 代码块，方便按章节开始实验
- 更新 AgentSeek `0.1.2` 的准备篇说明，并补充章节映射测试

## Verification
- `npm run build`
- `node --test scripts/homepage-preview.test.mjs`
- `npm run docs:test`
- `npm run assets:check`
- `npm run ci:test`
- `git diff --check`
