### PR TITLE
docs: align Chapter 14 preview placement

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,15 +200,6 @@ agentseek create deepagents/content-builder --checkout main --no-input
 agentseek create deepagents/mcp --checkout main --no-input
 ```
 
-#### 第 14 章：[Streaming — 实时观察主 Agent、子 Agent 与工具调用](https://datawhalechina.github.io/deepagents-in-action/chapters/ch14-streaming/)
-
-- 模板：[`deepagents/streaming`](https://github.com/agentseek-ai/agentseek-templates/tree/main/templates/deepagents/streaming)（由 [agentseek-templates PR #20](https://github.com/agentseek-ai/agentseek-templates/pull/20) 引入）
-- 实验：直接运行 Event Streaming v3 应用，观察 coordinator/subagent messages、工具生命周期、状态快照、最终输出和 raw protocol，并核对哪些字段来自官方协议、哪些由模板 adapter 生成。
-
-```bash
-agentseek create deepagents/streaming --checkout main --no-input
-```
-
 ### 前沿预览
 
 #### 第 13 章：[Grading Rubrics（评分量规）— 让 Agent 按验收标准自我迭代](https://datawhalechina.github.io/deepagents-in-action/chapters/ch13-grading-rubrics/)
@@ -218,6 +209,15 @@ agentseek create deepagents/streaming --checkout main --no-input
 
 ```bash
 agentseek create langchain/rubric --checkout main --no-input
+```
+
+#### 第 14 章：[Streaming — 实时观察主 Agent、子 Agent 与工具调用](https://datawhalechina.github.io/deepagents-in-action/chapters/ch14-streaming/)
+
+- 模板：[`deepagents/streaming`](https://github.com/agentseek-ai/agentseek-templates/tree/main/templates/deepagents/streaming)（由 [agentseek-templates PR #20](https://github.com/agentseek-ai/agentseek-templates/pull/20) 引入）
+- 实验：直接运行 Event Streaming v3 应用，观察 coordinator/subagent messages、工具生命周期、状态快照、最终输出和 raw protocol，并核对哪些字段来自官方协议、哪些由模板 adapter 生成。
+
+```bash
+agentseek create deepagents/streaming --checkout main --no-input
 ```
 
 后续课程内容将根据 Deep Agents 的官方能力演进持续更新。

--- a/scripts/chapters.json
+++ b/scripts/chapters.json
@@ -191,7 +191,7 @@
   "ch14-streaming": {
     "title": "Streaming — 实时观察主 Agent、子 Agent 与工具调用",
     "chapter": 14,
-    "section": "进阶篇",
+    "section": "前沿预览",
     "order": 16,
     "description": "运行 AgentSeek deepagents/streaming 专用模板，观察主 Agent、委派子 Agent、工具调用、状态快照、最终输出和 raw protocol，并区分官方字段与应用适配字段。",
     "slides": [

--- a/scripts/homepage-preview.test.mjs
+++ b/scripts/homepage-preview.test.mjs
@@ -22,9 +22,36 @@ const streamingChapterSource = await readFile(
   new URL('../content/ch14-streaming.md', import.meta.url),
   'utf8',
 );
+const readmeSource = await readFile(new URL('../README.md', import.meta.url), 'utf8');
 
-test('Chapter 13 starts the preview-feature section', () => {
+test('Chapters 13 and 14 share the preview-feature row', () => {
   assert.equal(manifest['ch13-grading-rubrics'].section, '前沿预览');
+  assert.equal(manifest['ch14-streaming'].section, '前沿预览');
+  assert.equal(
+    manifest['ch14-streaming'].order,
+    manifest['ch13-grading-rubrics'].order + 1,
+  );
+});
+
+test('README places Chapters 13 and 14 together in the preview section', () => {
+  let currentSection = '';
+  const chapters = [];
+
+  for (const line of readmeSource.split(/\r?\n/)) {
+    const sectionMatch = line.match(/^### (.+)$/);
+    if (sectionMatch) currentSection = sectionMatch[1];
+
+    const chapterMatch = line.match(/^#### 第 (\d+) 章：/);
+    if (chapterMatch) {
+      chapters.push({ chapter: Number(chapterMatch[1]), section: currentSection });
+    }
+  }
+
+  assert.deepEqual(
+    chapters.filter(({ section }) => section === '前沿预览').map(({ chapter }) => chapter),
+    [13, 14],
+  );
+  assert.equal(chapters.filter(({ chapter }) => chapter === 14).length, 1);
 });
 
 test('Chapter 13 publishes its video resource links', () => {
@@ -37,7 +64,6 @@ test('Chapter 13 publishes its video resource links', () => {
 });
 
 test('Chapter 14 publishes its video resource links', () => {
-  assert.equal(manifest['ch14-streaming'].section, '进阶篇');
   assert.deepEqual(manifest['ch14-streaming'].slides[0], {
     id: 'ch14',
     title: 'Lec 18: Streaming — 实时观察智能体和工具',
@@ -79,7 +105,7 @@ test('Chapter 14 points readers to the dedicated streaming template', async () =
 
   assert.deepEqual(chapterExperiments['ch14-streaming'], {
     template: 'deepagents/streaming',
-    note: '直接运行 Event Streaming v3 模板，观察主 Agent、子 Agent、工具生命周期、状态快照、最终输出和 raw protocol。',
+    note: '运行 Streaming 模板，观察 Agent 与工具事件流。',
     command: 'agentseek create deepagents/streaming --checkout main --no-input',
     source: 'https://github.com/agentseek-ai/agentseek-templates/tree/main/templates/deepagents/streaming',
   });
@@ -110,6 +136,18 @@ test('homepage keeps the experiment entry inside each chapter card', () => {
   assert.doesNotMatch(cardSource, /创建后/);
   assert.doesNotMatch(cardSource, /运行说明/);
   assert.doesNotMatch(indexSource, /TemplateLab/);
+});
+
+test('homepage experiment descriptions stay concise', async () => {
+  const { chapterExperiments } = await import('../src/data/chapter-experiments.mjs');
+
+  for (const [chapterId, experiment] of Object.entries(chapterExperiments)) {
+    assert.ok(
+      [...experiment.note].length <= 36,
+      `${chapterId} experiment note exceeds 36 characters`,
+    );
+    assert.doesNotMatch(experiment.note, /[\r\n]/);
+  }
 });
 
 test('every published numbered chapter maps to exactly one current template command', async () => {

--- a/src/components/ChapterCard.astro
+++ b/src/components/ChapterCard.astro
@@ -91,7 +91,7 @@ const chapterLabel = isExtra ? (preMatch ? preMatch[1] : 'EX') : String(chapter)
             <span data-copy-label>复制 AgentSeek 创建命令</span>
           </button>
         </div>
-        <p>{experiment.note}</p>
+        <p title={experiment.note}>{experiment.note}</p>
       </div>
     )}
   </div>
@@ -139,9 +139,12 @@ const chapterLabel = isExtra ? (preMatch ? preMatch[1] : 'EX') : String(chapter)
 
   .chapter-experiment p {
     margin: 0.4rem 0 0;
+    overflow: hidden;
     color: var(--color-ink-muted);
     font-size: 0.68rem;
     line-height: 1.5;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .chapter-experiment button {

--- a/src/data/chapter-experiments.mjs
+++ b/src/data/chapter-experiments.mjs
@@ -11,58 +11,58 @@ const experiment = (template, note) => ({
 export const chapterExperiments = {
   'ch01-agent-harness': experiment(
     'deepagents/default',
-    '从最小 create_deep_agent 项目识别 Runtime、Framework 与 Harness 的边界。',
+    '从最小 Agent 项目辨清框架、运行时与 Harness。',
   ),
   'ch02-quickstart': experiment(
     'deepagents/default',
-    '修改系统提示词和自定义工具，跑通第一个可工作的 Deep Agent。',
+    '修改提示词和工具，跑通第一个 Deep Agent。',
   ),
   'ch03-virtual-filesystem': experiment(
     'deepagents/content-builder',
-    '利用现成 FilesystemBackend 观察内容、中间结果和 Skills 如何落盘。',
+    '观察 FilesystemBackend 如何管理内容与中间结果。',
   ),
   'ch04-task-planning': experiment(
     'deepagents/research',
-    '通过 Todo 面板直接观察 write_todos 的计划生成与状态变化。',
+    '通过 Todo 面板观察计划生成与状态变化。',
   ),
   'ch05-subagents': experiment(
     'deepagents/research',
-    '观察主 Agent 将搜索委派给 research-agent，并比较两侧上下文。',
+    '观察主 Agent 委派搜索并隔离上下文。',
   ),
   'ch06-async-subagents': experiment(
     'deepagents/research',
-    '从同步研究应用开始，按本章将 researcher 拆成独立 graph 并接入 AsyncSubAgent。',
+    '拆分 researcher，接入异步子 Agent。',
   ),
   'ch07-skills': experiment(
     'deepagents/content-builder',
-    '使用内置 blog-post 与 social-media Skills 观察匹配和渐进式加载。',
+    '运行内置 Skills，观察匹配与渐进式加载。',
   ),
   'ch08-long-term-memory': experiment(
     'deepagents/content-builder',
-    '从内容应用开始，按本章加入 CompositeBackend、StoreBackend 和运行时 namespace。',
+    '接入 CompositeBackend，验证跨会话记忆。',
   ),
   'ch09-human-in-the-loop': experiment(
     'deepagents/mcp',
-    '从 MCP 应用开始，按本章为有副作用的工具配置 interrupt_on。',
+    '为有副作用的 MCP 工具配置人工审批。',
   ),
   'ch10-sandboxes': experiment(
     'deepagents/sandbox',
-    '选择 Daytona 或 LangSmith Sandbox，观察隔离执行、文件读写与清理。',
+    '选择沙箱后端，观察隔离执行与文件读写。',
   ),
   'ch11-filesystem-permissions': experiment(
     'deepagents/content-builder',
-    '从真实内容目录开始，按本章加入 FilesystemPermission 并划分访问边界。',
+    '配置 FilesystemPermission，划分文件访问边界。',
   ),
   'ch12-mcp': experiment(
     'deepagents/mcp',
-    '开箱验证 stdio/HTTP Server、工具发现、稳定前缀与名称冲突。',
+    '验证 MCP 工具发现、名称前缀与冲突处理。',
   ),
   'ch13-grading-rubrics': experiment(
     'langchain/rubric',
-    '先运行无需模型密钥的 Guided Demo，再观察 Evidence 与 Acceptance Gate。',
+    '运行 Guided Demo，观察 Evidence 验收闭环。',
   ),
   'ch14-streaming': experiment(
     'deepagents/streaming',
-    '直接运行 Event Streaming v3 模板，观察主 Agent、子 Agent、工具生命周期、状态快照、最终输出和 raw protocol。',
+    '运行 Streaming 模板，观察 Agent 与工具事件流。',
   ),
 };


### PR DESCRIPTION
## Summary

- place Chapter 14 beside Chapter 13 in the homepage preview section
- move the README Chapter 14 entry into the preview section after Chapter 13
- shorten experiment descriptions and keep card descriptions on one line
- add regression coverage for homepage and README chapter placement

Follow-up to #99, which was merged before these final placement fixes reached its branch head.

## Verification

- `node --test scripts/homepage-preview.test.mjs`
- `npm run assets:test`
- `npm run assets:check`
- `npm run docs:test`
- `npm run ci:test`
- `npm run build`
