### PR TITLE
docs: clarify routed skill store paths

### DIFF
--- a/content/ch07-skills.md
+++ b/content/ch07-skills.md
@@ -402,6 +402,7 @@ from dataclasses import dataclass
 
 from deepagents import FilesystemPermission, create_deep_agent
 from deepagents.backends import CompositeBackend, StateBackend, StoreBackend
+from deepagents.backends.utils import create_file_data
 from langgraph.store.memory import InMemoryStore
 
 
@@ -416,6 +417,18 @@ def org_skill_namespace(rt):
 
 
 store = InMemoryStore()
+store.put(
+    namespace=("curated-skills", "org-acme"),
+    # /skills/ 是 CompositeBackend 的挂载前缀；Store 内使用路由相对路径。
+    key="/test-skill/SKILL.md",
+    value=create_file_data("""---
+name: test-skill
+description: 用于验证只读 Skill 的发现与加载。
+---
+
+# test-skill
+"""),
+)
 
 agent = create_deep_agent(
     model="anthropic:claude-sonnet-4-6",
@@ -441,6 +454,8 @@ agent = create_deep_agent(
 ```
 
 核心逻辑：`mode="deny"` 拒绝所有对 `/skills/**` 路径的写入操作。Agent 可以正常发现和读取 Skill 内容，但 `write_file` 和 `edit_file` 调用会被直接拦截并返回权限错误。Skill 库的更新只能通过管理员代码直接操作 Store 完成。
+
+这里要区分 **Agent 可见路径** 与 **路由内部路径**。`CompositeBackend` 收到 `/skills/test-skill/SKILL.md` 后，会先剥离挂载前缀 `/skills/`，再把 `/test-skill/SKILL.md` 交给内部 `StoreBackend`。因此，通过 Store API 预填这条路由时，key 应写成 `/test-skill/SKILL.md`；如果误写成 `/skills/test-skill/SKILL.md`，外层恢复路由前缀后就会出现 `/skills/skills/test-skill/SKILL.md`。只有直接把 `StoreBackend` 作为 Agent 的根 Backend、没有经过 `CompositeBackend` 路由时，Store key 才保留完整的 `/skills/...` 路径。
 
 本地调试或自托管服务中，需要在调用时传入组织上下文，例如：
 

--- a/content/ch08-long-term-memory.md
+++ b/content/ch08-long-term-memory.md
@@ -245,10 +245,10 @@ agent = create_deep_agent(
         default=StateBackend(),
         routes={
             "/memories/": StoreBackend(
-                namespace=assistant_namespace,
+                namespace=lambda rt: (*assistant_namespace(rt), "memories"),
             ),
             "/skills/": StoreBackend(
-                namespace=assistant_namespace,
+                namespace=lambda rt: (*assistant_namespace(rt), "skills"),
             ),
         },
     ),
@@ -271,10 +271,10 @@ agent = create_deep_agent(
         default=StateBackend(),
         routes={
             "/memories/": StoreBackend(
-                namespace=user_namespace,
+                namespace=lambda rt: (*user_namespace(rt), "memories"),
             ),
             "/skills/": StoreBackend(
-                namespace=user_namespace,
+                namespace=lambda rt: (*user_namespace(rt), "skills"),
             ),
         },
     ),
@@ -683,18 +683,42 @@ agent = create_deep_agent(
 }
 ```
 
-旧版本中 `content` 可能是 `list[str]`，但该格式只是向后兼容。不要手写底层 JSON，Agent 外部（后端服务、初始化脚本）预填记忆时应使用 `create_file_data` 辅助函数：
+旧版本中 `content` 可能是 `list[str]`，但该格式只是向后兼容。不要手写底层 JSON，Agent 外部（后端服务、初始化脚本）预填记忆时应使用 `create_file_data` 辅助函数。
+
+外部写入时，Store key 取决于 `StoreBackend` 是否挂载在 `CompositeBackend` 路由下：
+
+| Backend 配置 | Agent 可见路径 | Store key |
+|---|---|---|
+| 直接使用 `StoreBackend` | `/skills/langgraph-docs/SKILL.md` | `/skills/langgraph-docs/SKILL.md` |
+| 挂载到 `routes={"/skills/": StoreBackend(...)}` | `/skills/langgraph-docs/SKILL.md` | `/langgraph-docs/SKILL.md` |
+
+下面按 `CompositeBackend` 路由方式预填记忆和 Skill。两条路由使用不同 namespace，既保留各自的存储边界，也避免相同相对 key 互相覆盖：
 
 ```python
+from deepagents.backends import CompositeBackend, StateBackend, StoreBackend
 from deepagents.backends.utils import create_file_data
 from langgraph.store.memory import InMemoryStore
 
 store = InMemoryStore()
+memory_namespace = ("my-agent", "memories")
+skill_namespace = ("my-agent", "skills")
+
+backend = CompositeBackend(
+    default=StateBackend(),
+    routes={
+        "/memories/": StoreBackend(
+            namespace=lambda _rt: memory_namespace,
+        ),
+        "/skills/": StoreBackend(
+            namespace=lambda _rt: skill_namespace,
+        ),
+    },
+)
 
 # 预填 Agent 记忆
 store.put(
-    ("my-agent",),                          # namespace
-    "/memories/AGENTS.md",                  # 文件路径
+    memory_namespace,
+    "/AGENTS.md",  # Agent 可见路径是 /memories/AGENTS.md
     create_file_data("""## Response style
 - Keep responses concise
 - Use code examples where possible
@@ -703,8 +727,8 @@ store.put(
 
 # 预填一个 Skill
 store.put(
-    ("my-agent",),
-    "/skills/langgraph-docs/SKILL.md",
+    skill_namespace,
+    "/langgraph-docs/SKILL.md",  # Agent 可见路径会补回 /skills/
     create_file_data("""---
 name: langgraph-docs
 description: Fetch relevant LangGraph documentation to provide accurate guidance.
@@ -716,6 +740,8 @@ Use the fetch_url tool to read https://docs.langchain.com/llms.txt, then fetch r
 """),
 )
 ```
+
+如果这里把 key 写成 `/skills/langgraph-docs/SKILL.md`，`CompositeBackend` 在返回结果时还会补一次 `/skills/`，最终暴露成错误的 `/skills/skills/langgraph-docs/SKILL.md`。反过来，如果 Agent 直接使用 `StoreBackend` 而没有路由层，就应保留完整虚拟路径。
 
 > 使用 LangSmith 部署时，也可以通过 SDK 远程写入：`await client.store.put_item(namespace, key, value)`
 

--- a/content/ch11-filesystem-permissions.md
+++ b/content/ch11-filesystem-permissions.md
@@ -544,6 +544,8 @@ PolicyWrapper.write(...)
 
 包装器必须保持 Backend 协议的返回类型和路径语义。策略拒绝应返回相应结果对象中的 `error`，让文件工具得到可处理的结构化失败；策略放行时则原样返回内部 Backend 的结果。
 
+> **CompositeBackend 路由内的路径语义**：如果把包装器放在 `routes={"/skills/": PolicyWrapper(...)}` 内部，`CompositeBackend` 会先剥离 `/skills/`，因此包装器看到的是 `/test-skill/SKILL.md`，而不是 `/skills/test-skill/SKILL.md`。此时 `deny_prefixes=["/skills/"]` 不会命中。若目标只是让整条 `/skills/**` 路由只读，优先在 Agent 层使用 `FilesystemPermission(paths=["/skills/**"], operations=["write"], mode="deny")`；确实需要内部动态策略时，可用 `deny_prefixes=["/"]` 覆盖该路由 Backend 的全部写入。
+
 这段代码尚未实现 `delete()`。如果所用 Backend 和工具集支持删除，应按同一模式增加 `delete()` 与 `DeleteResult`，否则删除操作可能绕过这项策略。
 
 | 需求 | 推荐机制 |


### PR DESCRIPTION
## Summary
- use route-relative Store keys when skills are mounted through CompositeBackend
- isolate memory and skill routes with distinct namespaces
- document Agent-visible permissions and stripped paths seen by inner policy wrappers

## Verification
- 27 Node tests passed
- npm run assets:check
- npm run build (19 pages)
- git diff --check